### PR TITLE
Add project detection, multi-project support, and security fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,13 @@ The extension supports workspaces where the app project is **not** at the root �
 
 **How it works:**
 
-When you run any WinApp command, the extension resolves the target project directory using this priority:
+When you run a project-context WinApp command — such as **Initialize Project**, **Restore/Update Packages**, **Generate Manifest**, **Update Manifest Assets**, **Add Manifest Execution Alias**, **Generate Certificate**, **Unregister Package**, or **Get WinApp Path** — the extension resolves the target project directory using this priority:
 
 1. **`winapp.appDirectories` setting** — If specified in `.vscode/settings.json`, the extension uses these paths directly (no scanning). With one entry, it auto-selects; with multiple, it shows a QuickPick.
 2. **Project at workspace root** — If a recognized project exists at the root, commands run there immediately.
 3. **Automatic scan** — Searches the workspace for compatible projects and prompts if multiple are found.
+
+Commands that already take an explicit target — such as **Run Application**, **Create MSIX Package** (input folder), **Sign Package**, **Install Certificate**, and **Certificate Info** (file pickers) — operate on the file or folder you select and do not run project detection.
 
 **Configuration (optional):**
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To skip automatic scanning, add the `winapp.appDirectories` setting to your work
 
 | Scenario | Behavior |
 |----------|----------|
-| Setting has 1 entry | All commands auto-target that directory |
+| Setting has 1 entry | Project-context commands auto-target that directory |
 | Setting has multiple entries | QuickPick prompt to choose which project |
 | Setting is absent or empty | Falls back to auto-detection (see below) |
 

--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
     "clean": "node -e \"require('fs').rmSync('bin', {recursive: true, force: true}); require('fs').rmSync('out', {recursive: true, force: true}); require('fs').rmSync('dist', {recursive: true, force: true});\"",
     "download-cli": "pwsh -NoProfile -Command \"& ./scripts/download-cli.ps1\"",
     "download-cli:latest": "pwsh -NoProfile -Command \"& ./scripts/download-cli.ps1 -Tag latest\"",
-    "test:unit": "tsc -p ./ && node -e \"require('fs').cpSync('src/test/fixtures','out/test/fixtures',{recursive:true})\" && mocha out/test/project-detection.test.js && npx tsx --test src/test/extension-field-validator.test.ts src/test/extension-templates.test.ts src/test/manifest-edge-cases.test.ts src/test/manifest-parser.test.ts src/test/manifest-validator.test.ts src/test/redos-prevention.test.ts src/test/xml-utils.test.ts"
+    "test:unit": "tsc -p ./ && node -e \"require('fs').cpSync('src/test/fixtures','out/test/fixtures',{recursive:true})\" && mocha out/test/project-detection.test.js && npx tsx --test src/test/extension-field-validator.test.ts src/test/extension-templates.test.ts src/test/manifest-edge-cases.test.ts src/test/manifest-parser.test.ts src/test/manifest-validator.test.ts src/test/project-resolver.test.ts src/test/redos-prevention.test.ts src/test/xml-utils.test.ts"
   },
   "dependencies": {
     "@xmldom/xmldom": "^0.9.9",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,19 @@
         "category": "WinApp"
       }
     ],
+    "configuration": {
+      "title": "WinApp",
+      "properties": {
+        "winapp.appDirectories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Relative paths (from the workspace root) to app project directories. When set, WinApp commands target these directories instead of auto-scanning. If multiple entries are provided, you'll be prompted to choose."
+        }
+      }
+    },
     "customEditors": [
       {
         "viewType": "winapp.manifestEditor",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,8 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { spawn } from 'child_process';
 import { getWinappCliPath, WINAPP_CLI_CALLER_VALUE } from './winapp-cli-utils';
-import { detectProjectAt, detectProjects, getDisplayFilePath } from './project-detection';
+import { detectProjects } from './project-detection';
+import { resolveProjectDirectory as resolveProjectDirectoryCore } from './project-resolver';
 import { glob } from 'glob';
 import { ManifestEditorProvider } from './manifest-editor/manifest-editor-provider';
 
@@ -80,76 +81,27 @@ function escapePowerShellArg(value: string): string {
  * Resolves the project directory for commands that need a winapp project context.
  * Priority: 1) winapp.appDirectories setting, 2) project at workspace root, 3) scan workspace.
  * Returns the absolute path to the selected project directory, or undefined if cancelled.
+ *
+ * The resolution logic lives in `project-resolver.ts`; this wrapper supplies the
+ * VS Code-backed dependencies (settings, QuickPick, progress UI).
  */
 async function resolveProjectDirectory(workspacePath: string): Promise<string | undefined> {
-	// Check for explicit appDirectories setting
-	const config = vscode.workspace.getConfiguration('winapp');
-	const appDirs: string[] = config.get('appDirectories', []);
-
-	if (appDirs.length > 0) {
-		// Validate paths are contained within workspace
-		const validDirs = appDirs.filter(dir => {
-			const resolved = path.resolve(workspacePath, dir);
-			const relative = path.relative(workspacePath, resolved);
-			return !relative.startsWith('..') && !path.isAbsolute(relative);
-		});
-
-		if (validDirs.length === 0) {
-			vscode.window.showWarningMessage('All winapp.appDirectories entries resolve outside the workspace and were ignored.');
-		} else if (validDirs.length === 1) {
-			return path.resolve(workspacePath, validDirs[0]);
-		} else {
-			const items = validDirs.map(dir => ({
-				label: `$(folder) ${dir}`,
-				directory: path.resolve(workspacePath, dir)
-			}));
-
-			const picked = await vscode.window.showQuickPick(items, {
-				placeHolder: 'Which project would you like to target?'
-			});
+	return resolveProjectDirectoryCore(workspacePath, {
+		getAppDirectories: () =>
+			vscode.workspace.getConfiguration('winapp').get<string[]>('appDirectories', []),
+		showWarning: (message) => {
+			vscode.window.showWarningMessage(message);
+		},
+		pickDirectory: async (items, placeHolder) => {
+			const picked = await vscode.window.showQuickPick(items, { placeHolder });
 			return picked?.directory;
-		}
-	}
-
-	// If there's a project at the workspace root, use it directly
-	const rootProject = await detectProjectAt(workspacePath, workspacePath);
-	if (rootProject) {
-		return workspacePath;
-	}
-
-	// Search for projects in the workspace
-	const projects = await vscode.window.withProgress(
-		{ location: vscode.ProgressLocation.Notification, title: 'Searching for app projects...' },
-		async () => detectProjects(workspacePath)
-	);
-
-	if (projects.length === 0) {
-		// No projects found — fall back to workspace root
-		return workspacePath;
-	}
-
-	if (projects.length === 1) {
-		// Single project — auto-select it
-		return projects[0].directory;
-	}
-
-	// Multiple projects — let user pick
-	const maxProjects = 10;
-	const items = projects.map(p => ({
-		label: `$(file-code) ${p.type} project`,
-		description: getDisplayFilePath(p),
-		directory: p.directory
-	}));
-
-	const placeHolder = projects.length >= maxProjects
-		? 'Which project? (Search stopped at 10 entries)'
-		: 'Which project would you like to target?';
-
-	const picked = await vscode.window.showQuickPick(items, { placeHolder });
-	if (!picked) {
-		return undefined;
-	}
-	return picked.directory;
+		},
+		scanProjects: async (root) =>
+			vscode.window.withProgress(
+				{ location: vscode.ProgressLocation.Notification, title: 'Searching for app projects...' },
+				async () => detectProjects(root)
+			)
+	});
 }
 
 /**
@@ -536,7 +488,12 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
-			await runWinappCommand(extensionPath, 'restore', workspacePath);
+			const projectDir = await resolveProjectDirectory(workspacePath);
+			if (!projectDir) {
+				return;
+			}
+
+			await runWinappCommand(extensionPath, 'restore', projectDir);
 		})
 	);
 
@@ -545,6 +502,11 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('winapp.update', async () => {
 			const workspacePath = getWorkspacePath();
 			if (!workspacePath) {
+				return;
+			}
+
+			const projectDir = await resolveProjectDirectory(workspacePath);
+			if (!projectDir) {
 				return;
 			}
 
@@ -558,7 +520,7 @@ export function activate(context: vscode.ExtensionContext) {
 				command += ` --setup-sdks ${sdkMode}`;
 			}
 
-			await runWinappCommand(extensionPath, command, workspacePath);
+			await runWinappCommand(extensionPath, command, projectDir);
 		})
 	);
 
@@ -643,6 +605,11 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
+			const projectDir = await resolveProjectDirectory(workspacePath);
+			if (!projectDir) {
+				return;
+			}
+
 			const template = await vscode.window.showQuickPick(
 				['packaged', 'sparse'],
 				{ placeHolder: 'Select manifest template type' }
@@ -653,7 +620,7 @@ export function activate(context: vscode.ExtensionContext) {
 				command += ` --template ${template}`;
 			}
 
-			await runWinappCommand(extensionPath, command, workspacePath);
+			await runWinappCommand(extensionPath, command, projectDir);
 		})
 	);
 
@@ -662,6 +629,11 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('winapp.manifestUpdateAssets', async () => {
 			const workspacePath = getWorkspacePath();
 			if (!workspacePath) {
+				return;
+			}
+
+			const projectDir = await resolveProjectDirectory(workspacePath);
+			if (!projectDir) {
 				return;
 			}
 
@@ -674,7 +646,7 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
-			await runWinappCommand(extensionPath, `manifest update-assets "${imagePath}"`, workspacePath);
+			await runWinappCommand(extensionPath, `manifest update-assets "${imagePath}"`, projectDir);
 		})
 	);
 
@@ -683,6 +655,11 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('winapp.certGenerate', async () => {
 			const workspacePath = getWorkspacePath();
 			if (!workspacePath) {
+				return;
+			}
+
+			const projectDir = await resolveProjectDirectory(workspacePath);
+			if (!projectDir) {
 				return;
 			}
 
@@ -696,7 +673,7 @@ export function activate(context: vscode.ExtensionContext) {
 				command += ' --install';
 			}
 
-			await runWinappCommand(extensionPath, command, workspacePath);
+			await runWinappCommand(extensionPath, command, projectDir);
 		})
 	);
 
@@ -807,6 +784,11 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
+			const projectDir = await resolveProjectDirectory(workspacePath);
+			if (!projectDir) {
+				return;
+			}
+
 			const global = await vscode.window.showQuickPick(
 				['Local (.winapp in workspace)', 'Global (shared cache)'],
 				{ placeHolder: 'Which path to retrieve?' }
@@ -817,7 +799,7 @@ export function activate(context: vscode.ExtensionContext) {
 				command += ' --global';
 			}
 
-			await runWinappCommand(extensionPath, command, workspacePath);
+			await runWinappCommand(extensionPath, command, projectDir);
 		})
 	);
 
@@ -829,7 +811,12 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
-			await runWinappCommand(extensionPath, 'manifest add-alias', workspacePath);
+			const projectDir = await resolveProjectDirectory(workspacePath);
+			if (!projectDir) {
+				return;
+			}
+
+			await runWinappCommand(extensionPath, 'manifest add-alias', projectDir);
 		})
 	);
 
@@ -841,7 +828,12 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
-			await runWinappCommand(extensionPath, 'unregister', workspacePath);
+			const projectDir = await resolveProjectDirectory(workspacePath);
+			if (!projectDir) {
+				return;
+			}
+
+			await runWinappCommand(extensionPath, 'unregister', projectDir);
 		})
 	);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { spawn } from 'child_process';
 import { getWinappCliPath, WINAPP_CLI_CALLER_VALUE } from './winapp-cli-utils';
+import { detectProjectAt, detectProjects, getDisplayFilePath } from './project-detection';
 import { glob } from 'glob';
 import { ManifestEditorProvider } from './manifest-editor/manifest-editor-provider';
 
@@ -65,6 +66,90 @@ async function runWinappCommand(extensionPath: string, command: string, cwd: str
 
 	terminal.sendText(`& "${cliPath}" ${command}`);
 	return '';
+}
+
+/**
+ * Escapes a string for safe interpolation in a PowerShell single-quoted string.
+ * Single quotes in the value are doubled per PowerShell rules.
+ */
+function escapePowerShellArg(value: string): string {
+	return `'${value.replace(/'/g, "''")}'`;
+}
+
+/**
+ * Resolves the project directory for commands that need a winapp project context.
+ * Priority: 1) winapp.appDirectories setting, 2) project at workspace root, 3) scan workspace.
+ * Returns the absolute path to the selected project directory, or undefined if cancelled.
+ */
+async function resolveProjectDirectory(workspacePath: string): Promise<string | undefined> {
+	// Check for explicit appDirectories setting
+	const config = vscode.workspace.getConfiguration('winapp');
+	const appDirs: string[] = config.get('appDirectories', []);
+
+	if (appDirs.length > 0) {
+		// Validate paths are contained within workspace
+		const validDirs = appDirs.filter(dir => {
+			const resolved = path.resolve(workspacePath, dir);
+			const relative = path.relative(workspacePath, resolved);
+			return !relative.startsWith('..') && !path.isAbsolute(relative);
+		});
+
+		if (validDirs.length === 0) {
+			vscode.window.showWarningMessage('All winapp.appDirectories entries resolve outside the workspace and were ignored.');
+		} else if (validDirs.length === 1) {
+			return path.resolve(workspacePath, validDirs[0]);
+		} else {
+			const items = validDirs.map(dir => ({
+				label: `$(folder) ${dir}`,
+				directory: path.resolve(workspacePath, dir)
+			}));
+
+			const picked = await vscode.window.showQuickPick(items, {
+				placeHolder: 'Which project would you like to target?'
+			});
+			return picked?.directory;
+		}
+	}
+
+	// If there's a project at the workspace root, use it directly
+	const rootProject = await detectProjectAt(workspacePath, workspacePath);
+	if (rootProject) {
+		return workspacePath;
+	}
+
+	// Search for projects in the workspace
+	const projects = await vscode.window.withProgress(
+		{ location: vscode.ProgressLocation.Notification, title: 'Searching for app projects...' },
+		async () => detectProjects(workspacePath)
+	);
+
+	if (projects.length === 0) {
+		// No projects found — fall back to workspace root
+		return workspacePath;
+	}
+
+	if (projects.length === 1) {
+		// Single project — auto-select it
+		return projects[0].directory;
+	}
+
+	// Multiple projects — let user pick
+	const maxProjects = 10;
+	const items = projects.map(p => ({
+		label: `$(file-code) ${p.type} project`,
+		description: getDisplayFilePath(p),
+		directory: p.directory
+	}));
+
+	const placeHolder = projects.length >= maxProjects
+		? 'Which project? (Search stopped at 10 entries)'
+		: 'Which project would you like to target?';
+
+	const picked = await vscode.window.showQuickPick(items, { placeHolder });
+	if (!picked) {
+		return undefined;
+	}
+	return picked.directory;
 }
 
 /**
@@ -421,12 +506,20 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
+			// Resolve project directory (honors appDirectories setting)
+			const projectDir = await resolveProjectDirectory(workspacePath);
+			if (!projectDir) {
+				return;
+			}
+
+			const selectedPath = path.relative(workspacePath, projectDir) || '.';
+
 			const sdkMode = await vscode.window.showQuickPick(
 				['stable', 'preview', 'experimental', 'none'],
 				{ placeHolder: 'Select SDK installation mode' }
 			);
 
-			let command = 'init . --use-defaults';
+			let command = `init ${escapePowerShellArg(selectedPath)} --use-defaults`;
 			if (sdkMode && sdkMode !== 'stable') {
 				command += ` --setup-sdks ${sdkMode}`;
 			}

--- a/src/project-detection.ts
+++ b/src/project-detection.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 
@@ -45,38 +44,38 @@ const SKIP_DIRS = new Set([
  * Detects a project at a single directory (does not recurse).
  * Mirrors ProjectDetectionService.DetectProject from WinApp.Cli.
  */
-export function detectProjectAt(directory: string, searchRoot: string): DetectedProject | undefined {
+export async function detectProjectAt(directory: string, searchRoot: string): Promise<DetectedProject | undefined> {
 	const displayPath = getRelativeDisplayPath(directory, searchRoot);
 
 	// Tauri: check immediate subdirectories for tauri.conf.json
-	const tauriConf = findTauriConfFile(directory);
+	const tauriConf = await findTauriConfFile(directory);
 	if (tauriConf) {
 		return { type: 'Tauri', directory, displayPath, projectFileName: tauriConf };
 	}
 
 	// Electron: package.json with electron dependency
-	if (isElectronProject(directory)) {
+	if (await isElectronProject(directory)) {
 		return { type: 'Electron', directory, displayPath, projectFileName: 'package.json' };
 	}
 
 	// Flutter: pubspec.yaml
-	if (fs.existsSync(path.join(directory, 'pubspec.yaml'))) {
+	if (await fileExists(path.join(directory, 'pubspec.yaml'))) {
 		return { type: 'Flutter', directory, displayPath, projectFileName: 'pubspec.yaml' };
 	}
 
 	// .NET: *.csproj (only executable, non-test projects)
-	const csprojName = findExecutableCsproj(directory);
+	const csprojName = await findExecutableCsproj(directory);
 	if (csprojName) {
 		return { type: '.NET', directory, displayPath, projectFileName: csprojName };
 	}
 
 	// Rust: Cargo.toml
-	if (fs.existsSync(path.join(directory, 'Cargo.toml'))) {
+	if (await fileExists(path.join(directory, 'Cargo.toml'))) {
 		return { type: 'Rust', directory, displayPath, projectFileName: 'Cargo.toml' };
 	}
 
 	// C++: CMakeLists.txt
-	if (fs.existsSync(path.join(directory, 'CMakeLists.txt'))) {
+	if (await fileExists(path.join(directory, 'CMakeLists.txt'))) {
 		return { type: 'C++', directory, displayPath, projectFileName: 'CMakeLists.txt' };
 	}
 
@@ -95,7 +94,7 @@ export async function detectProjects(root: string, maxProjects: number = 10): Pr
 
 	while (queue.length > 0 && results.length < maxProjects) {
 		const current = queue.shift()!;
-		const detected = detectProjectAt(current, root);
+		const detected = await detectProjectAt(current, root);
 		if (detected) {
 			results.push(detected);
 			// Don't recurse into detected project directories
@@ -133,6 +132,15 @@ export async function detectProjects(root: string, maxProjects: number = 10): Pr
 	return results;
 }
 
+async function fileExists(filePath: string): Promise<boolean> {
+	try {
+		await fsp.access(filePath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 function getRelativeDisplayPath(directory: string, searchRoot: string): string {
 	const relative = path.relative(searchRoot, directory);
 	if (!relative || relative === '.') {
@@ -141,20 +149,20 @@ function getRelativeDisplayPath(directory: string, searchRoot: string): string {
 	return relative.replace(/\\/g, '/');
 }
 
-function findTauriConfFile(directory: string): string | undefined {
+async function findTauriConfFile(directory: string): Promise<string | undefined> {
 	try {
-		const entries = fs.readdirSync(directory, { withFileTypes: true });
+		const entries = await fsp.readdir(directory, { withFileTypes: true });
 		for (const entry of entries) {
 			if (!entry.isDirectory()) { continue; }
 			if (entry.name.startsWith('.')) { continue; }
 			const subDir = path.join(directory, entry.name);
 			try {
-				const stat = fs.lstatSync(subDir);
+				const stat = await fsp.lstat(subDir);
 				if (stat.isSymbolicLink()) { continue; }
 			} catch {
 				continue;
 			}
-			if (fs.existsSync(path.join(subDir, 'tauri.conf.json'))) {
+			if (await fileExists(path.join(subDir, 'tauri.conf.json'))) {
 				return `${entry.name}/tauri.conf.json`;
 			}
 		}
@@ -164,11 +172,11 @@ function findTauriConfFile(directory: string): string | undefined {
 	return undefined;
 }
 
-function isElectronProject(directory: string): boolean {
+async function isElectronProject(directory: string): Promise<boolean> {
 	const packageJsonPath = path.join(directory, 'package.json');
-	if (!fs.existsSync(packageJsonPath)) { return false; }
+	if (!await fileExists(packageJsonPath)) { return false; }
 	try {
-		const content = fs.readFileSync(packageJsonPath, 'utf-8');
+		const content = await fsp.readFile(packageJsonPath, 'utf-8');
 		const pkg = JSON.parse(content);
 		const deps = { ...pkg.dependencies, ...pkg.devDependencies };
 		return 'electron' in deps;
@@ -177,14 +185,14 @@ function isElectronProject(directory: string): boolean {
 	}
 }
 
-function findExecutableCsproj(directory: string): string | undefined {
+async function findExecutableCsproj(directory: string): Promise<string | undefined> {
 	try {
-		const entries = fs.readdirSync(directory);
+		const entries = await fsp.readdir(directory);
 		for (const entry of entries) {
 			if (!entry.endsWith('.csproj')) { continue; }
 			const filePath = path.join(directory, entry);
 			try {
-				const content = fs.readFileSync(filePath, 'utf-8');
+				const content = await fsp.readFile(filePath, 'utf-8');
 				if (isExecutableCsproj(content)) {
 					return entry;
 				}

--- a/src/project-resolver.ts
+++ b/src/project-resolver.ts
@@ -1,3 +1,4 @@
+import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { detectProjectAt, DetectedProject, getDisplayFilePath } from './project-detection';
 
@@ -51,18 +52,30 @@ export async function resolveProjectDirectory(
 	// 1) Explicit appDirectories setting.
 	const appDirs = deps.getAppDirectories();
 	if (appDirs.length > 0) {
-		// Validate paths are contained within the workspace.
-		const validDirs = appDirs.filter(dir => {
-			const resolved = path.resolve(workspacePath, dir);
-			const relative = path.relative(workspacePath, resolved);
-			return !relative.startsWith('..') && !path.isAbsolute(relative);
-		});
+		// Validate that each entry stays within the workspace (see isContainedInWorkspace).
+		const validDirs: string[] = [];
+		for (const dir of appDirs) {
+			if (await isContainedInWorkspace(workspacePath, dir)) {
+				validDirs.push(dir);
+			}
+		}
+		const droppedCount = appDirs.length - validDirs.length;
 
 		if (validDirs.length === 0) {
 			deps.showWarning('All winapp.appDirectories entries resolve outside the workspace and were ignored.');
-		} else if (validDirs.length === 1) {
-			return path.resolve(workspacePath, validDirs[0]);
 		} else {
+			// Surface a warning when some (but not all) entries were ignored so a
+			// misconfigured setting does not silently retarget the command.
+			if (droppedCount > 0) {
+				const noun = droppedCount === 1 ? 'entry' : 'entries';
+				const verb = droppedCount === 1 ? 'was' : 'were';
+				deps.showWarning(`${droppedCount} winapp.appDirectories ${noun} resolve outside the workspace and ${verb} ignored.`);
+			}
+
+			if (validDirs.length === 1) {
+				return path.resolve(workspacePath, validDirs[0]);
+			}
+
 			const items: ProjectQuickPickItem[] = validDirs.map(dir => ({
 				label: `$(folder) ${dir}`,
 				directory: path.resolve(workspacePath, dir)
@@ -102,4 +115,36 @@ export async function resolveProjectDirectory(
 		: 'Which project would you like to target?';
 
 	return deps.pickDirectory(items, placeHolder);
+}
+
+/**
+ * Determines whether `dir` (resolved relative to `workspacePath`) stays inside
+ * the workspace.
+ *
+ * Applies a lexical check first (rejecting `..` traversal and absolute paths),
+ * then — when the target exists on disk — a real-path check so that a symlink
+ * or junction living inside the workspace cannot point the command at a
+ * directory outside it. Non-existent targets cannot be reparse points, so the
+ * lexical result stands.
+ */
+async function isContainedInWorkspace(workspacePath: string, dir: string): Promise<boolean> {
+	const resolved = path.resolve(workspacePath, dir);
+	const relative = path.relative(workspacePath, resolved);
+	if (relative.startsWith('..') || path.isAbsolute(relative)) {
+		return false;
+	}
+
+	try {
+		const realWorkspace = await fsp.realpath(workspacePath);
+		const realResolved = await fsp.realpath(resolved);
+		const realRelative = path.relative(realWorkspace, realResolved);
+		if (realRelative.startsWith('..') || path.isAbsolute(realRelative)) {
+			return false;
+		}
+	} catch {
+		// The target (or workspace) does not exist yet — it cannot be a symlink
+		// escape, so the lexical check above is authoritative.
+	}
+
+	return true;
 }

--- a/src/project-resolver.ts
+++ b/src/project-resolver.ts
@@ -1,0 +1,105 @@
+import * as path from 'path';
+import { detectProjectAt, DetectedProject, getDisplayFilePath } from './project-detection';
+
+/**
+ * Maximum number of projects the workspace scan will surface before stopping.
+ * Mirrors the limit used by {@link detectProjects}.
+ */
+export const MAX_SCANNED_PROJECTS = 10;
+
+/**
+ * An item shown in the project-selection QuickPick.
+ */
+export interface ProjectQuickPickItem {
+	label: string;
+	description?: string;
+	directory: string;
+}
+
+/**
+ * Host-provided dependencies for {@link resolveProjectDirectory}.
+ *
+ * These are injected so the resolution logic can be unit-tested without the
+ * VS Code API. The real implementations live in `extension.ts`.
+ */
+export interface ProjectResolverDeps {
+	/** Returns the configured `winapp.appDirectories` entries (may be empty). */
+	getAppDirectories(): string[];
+	/** Surfaces a non-blocking warning to the user. */
+	showWarning(message: string): void;
+	/** Prompts the user to choose one of the candidate directories. */
+	pickDirectory(items: ProjectQuickPickItem[], placeHolder: string): Promise<string | undefined>;
+	/** Scans the workspace for compatible projects (typically shows progress UI). */
+	scanProjects(workspacePath: string): Promise<DetectedProject[]>;
+}
+
+/**
+ * Resolves the project directory for commands that need a winapp project context.
+ *
+ * Priority:
+ *   1. `winapp.appDirectories` setting (single entry auto-selects; multiple prompt).
+ *   2. A recognized project at the workspace root.
+ *   3. An automatic workspace scan (single result auto-selects; multiple prompt).
+ *
+ * Returns the absolute path to the selected project directory, the workspace
+ * root when no project is found, or `undefined` when the user cancels a prompt.
+ */
+export async function resolveProjectDirectory(
+	workspacePath: string,
+	deps: ProjectResolverDeps
+): Promise<string | undefined> {
+	// 1) Explicit appDirectories setting.
+	const appDirs = deps.getAppDirectories();
+	if (appDirs.length > 0) {
+		// Validate paths are contained within the workspace.
+		const validDirs = appDirs.filter(dir => {
+			const resolved = path.resolve(workspacePath, dir);
+			const relative = path.relative(workspacePath, resolved);
+			return !relative.startsWith('..') && !path.isAbsolute(relative);
+		});
+
+		if (validDirs.length === 0) {
+			deps.showWarning('All winapp.appDirectories entries resolve outside the workspace and were ignored.');
+		} else if (validDirs.length === 1) {
+			return path.resolve(workspacePath, validDirs[0]);
+		} else {
+			const items: ProjectQuickPickItem[] = validDirs.map(dir => ({
+				label: `$(folder) ${dir}`,
+				directory: path.resolve(workspacePath, dir)
+			}));
+			return deps.pickDirectory(items, 'Which project would you like to target?');
+		}
+	}
+
+	// 2) Project at the workspace root — use it directly.
+	const rootProject = await detectProjectAt(workspacePath, workspacePath);
+	if (rootProject) {
+		return workspacePath;
+	}
+
+	// 3) Scan the workspace for projects.
+	const projects = await deps.scanProjects(workspacePath);
+
+	if (projects.length === 0) {
+		// No projects found — fall back to the workspace root.
+		return workspacePath;
+	}
+
+	if (projects.length === 1) {
+		// Single project — auto-select it.
+		return projects[0].directory;
+	}
+
+	// Multiple projects — let the user pick.
+	const items: ProjectQuickPickItem[] = projects.map(p => ({
+		label: `$(file-code) ${p.type} project`,
+		description: getDisplayFilePath(p),
+		directory: p.directory
+	}));
+
+	const placeHolder = projects.length >= MAX_SCANNED_PROJECTS
+		? 'Which project? (Search stopped at 10 entries)'
+		: 'Which project would you like to target?';
+
+	return deps.pickDirectory(items, placeHolder);
+}

--- a/src/test/project-detection.test.ts
+++ b/src/test/project-detection.test.ts
@@ -44,7 +44,7 @@ describe('project-detection', () => {
 	});
 
 	describe('detectProjectAt', () => {
-		it('detects a .NET executable project', () => {
+		it('detects a .NET executable project', async () => {
 			createFile(path.join(tempDir, 'MyApp.csproj'), `
 				<Project Sdk="Microsoft.NET.Sdk">
 					<PropertyGroup>
@@ -54,13 +54,13 @@ describe('project-detection', () => {
 				</Project>
 			`);
 
-			const result = detectProjectAt(tempDir, tempDir);
+			const result = await detectProjectAt(tempDir, tempDir);
 			assert.ok(result);
 			assert.strictEqual(result.type, '.NET');
 			assert.strictEqual(result.projectFileName, 'MyApp.csproj');
 		});
 
-		it('detects a WinExe .NET project', () => {
+		it('detects a WinExe .NET project', async () => {
 			createFile(path.join(tempDir, 'WpfApp.csproj'), `
 				<Project Sdk="Microsoft.NET.Sdk">
 					<PropertyGroup>
@@ -69,12 +69,12 @@ describe('project-detection', () => {
 				</Project>
 			`);
 
-			const result = detectProjectAt(tempDir, tempDir);
+			const result = await detectProjectAt(tempDir, tempDir);
 			assert.ok(result);
 			assert.strictEqual(result.type, '.NET');
 		});
 
-		it('does not detect a .NET test project', () => {
+		it('does not detect a .NET test project', async () => {
 			createFile(path.join(tempDir, 'MyApp.Tests.csproj'), `
 				<Project Sdk="Microsoft.NET.Sdk">
 					<PropertyGroup>
@@ -84,11 +84,11 @@ describe('project-detection', () => {
 				</Project>
 			`);
 
-			const result = detectProjectAt(tempDir, tempDir);
+			const result = await detectProjectAt(tempDir, tempDir);
 			assert.strictEqual(result, undefined);
 		});
 
-		it('does not detect a .NET library project', () => {
+		it('does not detect a .NET library project', async () => {
 			createFile(path.join(tempDir, 'MyLib.csproj'), `
 				<Project Sdk="Microsoft.NET.Sdk">
 					<PropertyGroup>
@@ -97,97 +97,97 @@ describe('project-detection', () => {
 				</Project>
 			`);
 
-			const result = detectProjectAt(tempDir, tempDir);
+			const result = await detectProjectAt(tempDir, tempDir);
 			assert.strictEqual(result, undefined);
 		});
 
-		it('detects an Electron project', () => {
+		it('detects an Electron project', async () => {
 			createFile(path.join(tempDir, 'package.json'), JSON.stringify({
 				name: 'my-electron-app',
 				dependencies: { electron: '^28.0.0' }
 			}));
 
-			const result = detectProjectAt(tempDir, tempDir);
+			const result = await detectProjectAt(tempDir, tempDir);
 			assert.ok(result);
 			assert.strictEqual(result.type, 'Electron');
 			assert.strictEqual(result.projectFileName, 'package.json');
 		});
 
-		it('does not detect a non-Electron package.json', () => {
+		it('does not detect a non-Electron package.json', async () => {
 			createFile(path.join(tempDir, 'package.json'), JSON.stringify({
 				name: 'my-lib',
 				dependencies: { express: '^4.0.0' }
 			}));
 
-			const result = detectProjectAt(tempDir, tempDir);
+			const result = await detectProjectAt(tempDir, tempDir);
 			assert.strictEqual(result, undefined);
 		});
 
-		it('detects a Flutter project', () => {
+		it('detects a Flutter project', async () => {
 			createFile(path.join(tempDir, 'pubspec.yaml'), 'name: my_app\n');
 
-			const result = detectProjectAt(tempDir, tempDir);
+			const result = await detectProjectAt(tempDir, tempDir);
 			assert.ok(result);
 			assert.strictEqual(result.type, 'Flutter');
 			assert.strictEqual(result.projectFileName, 'pubspec.yaml');
 		});
 
-		it('detects a Rust project', () => {
+		it('detects a Rust project', async () => {
 			createFile(path.join(tempDir, 'Cargo.toml'), '[package]\nname = "my_app"\n');
 
-			const result = detectProjectAt(tempDir, tempDir);
+			const result = await detectProjectAt(tempDir, tempDir);
 			assert.ok(result);
 			assert.strictEqual(result.type, 'Rust');
 			assert.strictEqual(result.projectFileName, 'Cargo.toml');
 		});
 
-		it('detects a C++ project', () => {
+		it('detects a C++ project', async () => {
 			createFile(path.join(tempDir, 'CMakeLists.txt'), 'cmake_minimum_required(VERSION 3.20)\n');
 
-			const result = detectProjectAt(tempDir, tempDir);
+			const result = await detectProjectAt(tempDir, tempDir);
 			assert.ok(result);
 			assert.strictEqual(result.type, 'C++');
 			assert.strictEqual(result.projectFileName, 'CMakeLists.txt');
 		});
 
-		it('detects a Tauri project', () => {
+		it('detects a Tauri project', async () => {
 			createFile(path.join(tempDir, 'src-tauri', 'tauri.conf.json'), '{}');
 
-			const result = detectProjectAt(tempDir, tempDir);
+			const result = await detectProjectAt(tempDir, tempDir);
 			assert.ok(result);
 			assert.strictEqual(result.type, 'Tauri');
 			assert.strictEqual(result.projectFileName, 'src-tauri/tauri.conf.json');
 		});
 
-		it('returns undefined for empty directory', () => {
-			const result = detectProjectAt(tempDir, tempDir);
+		it('returns undefined for empty directory', async () => {
+			const result = await detectProjectAt(tempDir, tempDir);
 			assert.strictEqual(result, undefined);
 		});
 
-		it('sets displayPath to "." for root directory', () => {
+		it('sets displayPath to "." for root directory', async () => {
 			createFile(path.join(tempDir, 'Cargo.toml'), '[package]\n');
 
-			const result = detectProjectAt(tempDir, tempDir);
+			const result = await detectProjectAt(tempDir, tempDir);
 			assert.ok(result);
 			assert.strictEqual(result.displayPath, '.');
 		});
 
-		it('sets relative displayPath for nested directory', () => {
+		it('sets relative displayPath for nested directory', async () => {
 			const nested = path.join(tempDir, 'apps', 'my-app');
 			createFile(path.join(nested, 'Cargo.toml'), '[package]\n');
 
-			const result = detectProjectAt(nested, tempDir);
+			const result = await detectProjectAt(nested, tempDir);
 			assert.ok(result);
 			assert.strictEqual(result.displayPath, 'apps/my-app');
 		});
 
-		it('prioritizes Tauri over Electron when both markers present', () => {
+		it('prioritizes Tauri over Electron when both markers present', async () => {
 			createFile(path.join(tempDir, 'package.json'), JSON.stringify({
 				dependencies: { electron: '^28.0.0' }
 			}));
 			createFile(path.join(tempDir, 'src-tauri', 'tauri.conf.json'), '{}');
 
-			const result = detectProjectAt(tempDir, tempDir);
+			const result = await detectProjectAt(tempDir, tempDir);
 			assert.ok(result);
 			assert.strictEqual(result.type, 'Tauri');
 		});
@@ -276,7 +276,7 @@ describe('project-detection', () => {
 	});
 
 	describe('getDisplayFilePath', () => {
-		it('formats root project path correctly', () => {
+		it('formats root project path correctly', async () => {
 			const project: DetectedProject = {
 				type: 'Rust',
 				directory: '/some/path',
@@ -286,7 +286,7 @@ describe('project-detection', () => {
 			assert.strictEqual(getDisplayFilePath(project), './Cargo.toml');
 		});
 
-		it('formats nested project path correctly', () => {
+		it('formats nested project path correctly', async () => {
 			const project: DetectedProject = {
 				type: '.NET',
 				directory: '/some/path/apps/myapp',
@@ -298,7 +298,7 @@ describe('project-detection', () => {
 	});
 
 	describe('getProjectLabel', () => {
-		it('formats label correctly', () => {
+		it('formats label correctly', async () => {
 			const project: DetectedProject = {
 				type: '.NET',
 				directory: '/some/path',

--- a/src/test/project-resolver.test.ts
+++ b/src/test/project-resolver.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Unit tests for resolveProjectDirectory (src/project-resolver.ts).
+ *
+ * Verifies the project-resolution logic that every project-context WinApp
+ * command relies on: appDirectories handling, workspace-root detection, the
+ * automatic scan, and user-cancellation. Dependencies on the VS Code API are
+ * injected as fakes so the logic runs outside the extension host.
+ *
+ * Run: npx tsx --test src/test/project-resolver.test.ts
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	resolveProjectDirectory,
+	ProjectResolverDeps,
+	ProjectQuickPickItem
+} from '../project-resolver';
+import { DetectedProject } from '../project-detection';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function createTempDir(): string {
+	return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'winapp-resolver-')));
+}
+
+function removeTempDir(dir: string): void {
+	fs.rmSync(dir, { recursive: true, force: true });
+}
+
+/** Writes an executable (.NET) csproj so detectProjectAt recognizes a root project. */
+function writeExecutableCsproj(dir: string, name = 'App.csproj'): void {
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(dir, name),
+		'<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType></PropertyGroup></Project>'
+	);
+}
+
+function makeProject(directory: string, type: DetectedProject['type'] = '.NET'): DetectedProject {
+	return { type, directory, displayPath: '.', projectFileName: 'App.csproj' };
+}
+
+interface FakeCalls {
+	warnings: string[];
+	pickInvocations: { items: ProjectQuickPickItem[]; placeHolder: string }[];
+	scanInvocations: string[];
+}
+
+/**
+ * Builds a deps object with sensible defaults plus call recording.
+ * Override any field via `overrides`.
+ */
+function makeDeps(
+	overrides: Partial<ProjectResolverDeps>,
+	calls: FakeCalls
+): ProjectResolverDeps {
+	return {
+		getAppDirectories: () => [],
+		showWarning: (message) => { calls.warnings.push(message); },
+		pickDirectory: async (items, placeHolder) => {
+			calls.pickInvocations.push({ items, placeHolder });
+			return undefined;
+		},
+		scanProjects: async (root) => {
+			calls.scanInvocations.push(root);
+			return [];
+		},
+		...overrides
+	};
+}
+
+function emptyCalls(): FakeCalls {
+	return { warnings: [], pickInvocations: [], scanInvocations: [] };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('resolveProjectDirectory', () => {
+	describe('appDirectories setting', () => {
+		it('auto-selects the directory when exactly one entry is configured', async () => {
+			const ws = createTempDir();
+			try {
+				const calls = emptyCalls();
+				const deps = makeDeps({ getAppDirectories: () => ['apps/my-app'] }, calls);
+
+				const result = await resolveProjectDirectory(ws, deps);
+
+				assert.equal(result, path.resolve(ws, 'apps/my-app'));
+				// No scanning or prompting should occur.
+				assert.equal(calls.scanInvocations.length, 0);
+				assert.equal(calls.pickInvocations.length, 0);
+			} finally {
+				removeTempDir(ws);
+			}
+		});
+
+		it('prompts the user when multiple entries are configured', async () => {
+			const ws = createTempDir();
+			try {
+				const calls = emptyCalls();
+				const chosen = path.resolve(ws, 'apps/shell');
+				const deps = makeDeps({
+					getAppDirectories: () => ['apps/my-app', 'apps/shell'],
+					pickDirectory: async (items, placeHolder) => {
+						calls.pickInvocations.push({ items, placeHolder });
+						return chosen;
+					}
+				}, calls);
+
+				const result = await resolveProjectDirectory(ws, deps);
+
+				assert.equal(result, chosen);
+				assert.equal(calls.pickInvocations.length, 1);
+				assert.equal(calls.pickInvocations[0].items.length, 2);
+				assert.equal(calls.scanInvocations.length, 0);
+			} finally {
+				removeTempDir(ws);
+			}
+		});
+
+		it('returns undefined when the user cancels the multi-entry prompt', async () => {
+			const ws = createTempDir();
+			try {
+				const calls = emptyCalls();
+				const deps = makeDeps({
+					getAppDirectories: () => ['apps/a', 'apps/b']
+					// default pickDirectory returns undefined (cancel)
+				}, calls);
+
+				const result = await resolveProjectDirectory(ws, deps);
+
+				assert.equal(result, undefined);
+				assert.equal(calls.pickInvocations.length, 1);
+			} finally {
+				removeTempDir(ws);
+			}
+		});
+
+		it('warns and falls through to detection when all entries are outside the workspace', async () => {
+			const ws = createTempDir();
+			try {
+				writeExecutableCsproj(ws); // root project exists
+				const calls = emptyCalls();
+				const deps = makeDeps({
+					getAppDirectories: () => ['../outside', path.resolve(os.tmpdir(), 'elsewhere')]
+				}, calls);
+
+				const result = await resolveProjectDirectory(ws, deps);
+
+				// Falls back to the root-project branch.
+				assert.equal(result, ws);
+				assert.equal(calls.warnings.length, 1);
+				assert.match(calls.warnings[0], /outside the workspace/i);
+			} finally {
+				removeTempDir(ws);
+			}
+		});
+	});
+
+	describe('workspace-root project', () => {
+		it('uses the workspace root directly when a project exists there', async () => {
+			const ws = createTempDir();
+			try {
+				writeExecutableCsproj(ws);
+				const calls = emptyCalls();
+				const deps = makeDeps({}, calls);
+
+				const result = await resolveProjectDirectory(ws, deps);
+
+				assert.equal(result, ws);
+				// Should not scan when a root project is present.
+				assert.equal(calls.scanInvocations.length, 0);
+				assert.equal(calls.pickInvocations.length, 0);
+			} finally {
+				removeTempDir(ws);
+			}
+		});
+	});
+
+	describe('automatic scan', () => {
+		it('falls back to the workspace root when no projects are found', async () => {
+			const ws = createTempDir(); // empty, no root project
+			try {
+				const calls = emptyCalls();
+				const deps = makeDeps({ scanProjects: async (root) => { calls.scanInvocations.push(root); return []; } }, calls);
+
+				const result = await resolveProjectDirectory(ws, deps);
+
+				assert.equal(result, ws);
+				assert.equal(calls.scanInvocations.length, 1);
+				assert.equal(calls.pickInvocations.length, 0);
+			} finally {
+				removeTempDir(ws);
+			}
+		});
+
+		it('auto-selects the single scanned project without prompting', async () => {
+			const ws = createTempDir();
+			try {
+				const projectDir = path.join(ws, 'src', 'MyApp');
+				const calls = emptyCalls();
+				const deps = makeDeps({
+					scanProjects: async (root) => { calls.scanInvocations.push(root); return [makeProject(projectDir)]; }
+				}, calls);
+
+				const result = await resolveProjectDirectory(ws, deps);
+
+				assert.equal(result, projectDir);
+				assert.equal(calls.pickInvocations.length, 0);
+			} finally {
+				removeTempDir(ws);
+			}
+		});
+
+		it('prompts the user when multiple projects are scanned', async () => {
+			const ws = createTempDir();
+			try {
+				const a = path.join(ws, 'apps', 'a');
+				const b = path.join(ws, 'apps', 'b');
+				const calls = emptyCalls();
+				const deps = makeDeps({
+					scanProjects: async () => [makeProject(a, '.NET'), makeProject(b, 'Rust')],
+					pickDirectory: async (items, placeHolder) => {
+						calls.pickInvocations.push({ items, placeHolder });
+						return b;
+					}
+				}, calls);
+
+				const result = await resolveProjectDirectory(ws, deps);
+
+				assert.equal(result, b);
+				assert.equal(calls.pickInvocations.length, 1);
+				assert.equal(calls.pickInvocations[0].items.length, 2);
+			} finally {
+				removeTempDir(ws);
+			}
+		});
+
+		it('returns undefined when the user cancels the multi-project prompt', async () => {
+			const ws = createTempDir();
+			try {
+				const calls = emptyCalls();
+				const deps = makeDeps({
+					scanProjects: async () => [
+						makeProject(path.join(ws, 'a')),
+						makeProject(path.join(ws, 'b'))
+					]
+					// default pickDirectory returns undefined
+				}, calls);
+
+				const result = await resolveProjectDirectory(ws, deps);
+
+				assert.equal(result, undefined);
+			} finally {
+				removeTempDir(ws);
+			}
+		});
+
+		it('uses the "search stopped" placeholder when the scan hits the project limit', async () => {
+			const ws = createTempDir();
+			try {
+				const calls = emptyCalls();
+				const many = Array.from({ length: 10 }, (_, i) => makeProject(path.join(ws, `p${i}`)));
+				const deps = makeDeps({
+					scanProjects: async () => many,
+					pickDirectory: async (items, placeHolder) => {
+						calls.pickInvocations.push({ items, placeHolder });
+						return many[0].directory;
+					}
+				}, calls);
+
+				await resolveProjectDirectory(ws, deps);
+
+				assert.equal(calls.pickInvocations.length, 1);
+				assert.match(calls.pickInvocations[0].placeHolder, /Search stopped/i);
+			} finally {
+				removeTempDir(ws);
+			}
+		});
+	});
+});

--- a/src/test/project-resolver.test.ts
+++ b/src/test/project-resolver.test.ts
@@ -159,6 +159,83 @@ describe('resolveProjectDirectory', () => {
 				removeTempDir(ws);
 			}
 		});
+
+		it('warns and uses the sole valid entry when some entries are outside the workspace', async () => {
+			const ws = createTempDir();
+			try {
+				const calls = emptyCalls();
+				// One in-workspace entry, one outside.
+				const deps = makeDeps({
+					getAppDirectories: () => ['apps/my-app', '../outside']
+				}, calls);
+
+				const result = await resolveProjectDirectory(ws, deps);
+
+				assert.equal(result, path.resolve(ws, 'apps/my-app'));
+				// The dropped entry must surface a warning rather than silently retargeting.
+				assert.equal(calls.warnings.length, 1);
+				assert.match(calls.warnings[0], /1 winapp\.appDirectories entry .*ignored/i);
+				// A single valid entry is auto-selected — no prompt.
+				assert.equal(calls.pickInvocations.length, 0);
+			} finally {
+				removeTempDir(ws);
+			}
+		});
+
+		it('warns and prompts among the remaining valid entries when some are outside', async () => {
+			const ws = createTempDir();
+			try {
+				const calls = emptyCalls();
+				const chosen = path.resolve(ws, 'apps/b');
+				const deps = makeDeps({
+					getAppDirectories: () => ['apps/a', 'apps/b', '../outside'],
+					pickDirectory: async (items, placeHolder) => {
+						calls.pickInvocations.push({ items, placeHolder });
+						return chosen;
+					}
+				}, calls);
+
+				const result = await resolveProjectDirectory(ws, deps);
+
+				assert.equal(result, chosen);
+				assert.equal(calls.warnings.length, 1);
+				assert.match(calls.warnings[0], /1 winapp\.appDirectories entry .*ignored/i);
+				// Only the two valid entries are offered.
+				assert.equal(calls.pickInvocations.length, 1);
+				assert.equal(calls.pickInvocations[0].items.length, 2);
+			} finally {
+				removeTempDir(ws);
+			}
+		});
+
+		it('rejects a junction inside the workspace that targets a directory outside it', async () => {
+			const ws = createTempDir();
+			const outside = createTempDir();
+			try {
+				const link = path.join(ws, 'linked-app');
+				try {
+					// Windows directory junctions do not require elevation.
+					fs.symlinkSync(outside, link, 'junction');
+				} catch {
+					// Environment cannot create the link — nothing to assert.
+					return;
+				}
+
+				const calls = emptyCalls();
+				const deps = makeDeps({ getAppDirectories: () => ['linked-app'] }, calls);
+
+				const result = await resolveProjectDirectory(ws, deps);
+
+				// The junction escapes the workspace, so it is ignored and we fall
+				// through to the scan, which finds nothing → workspace root.
+				assert.equal(result, ws);
+				assert.equal(calls.warnings.length, 1);
+				assert.match(calls.warnings[0], /outside the workspace/i);
+			} finally {
+				removeTempDir(ws);
+				removeTempDir(outside);
+			}
+		});
 	});
 
 	describe('workspace-root project', () => {


### PR DESCRIPTION
Ports the project detection and multi-project workspace support from winappCli PR #586, including all review feedback fixes.

## Changes

**Security:**
- \scapePowerShellArg()\ prevents command injection via malicious folder names (H2)
- Workspace containment validation rejects \ppDirectories\ entries that escape the workspace via \../\ or absolute paths (M3)

**Features:**
- \esolveProjectDirectory()\ — unified project resolution with priority: appDirectories setting → root project → workspace scan
- \winapp.appDirectories\ configuration setting for explicit project targeting
- Init command now uses shared resolution logic (honors appDirectories, shows QuickPick for multi-project)

**Correctness:**
- \detectProjectAt\ and all helpers (\indTauriConfFile\, \isElectronProject\, \indExecutableCsproj\) fully async with \s/promises\
- No more synchronous I/O blocking the extension host during detection

**Tests:**
- All 598 unit tests passing (25 mocha + 573 node:test)