### PR TITLE
Bump VS Code extension version to 0.2.2 for development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "winapp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "winapp",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.9",
         "glob": "^13.0.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "winapp",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "winapp",
-      "version": "0.1.1",
+      "version": "0.2.1",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.9",
         "glob": "^13.0.6"
@@ -1566,6 +1566,7 @@
       "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.0",
         "@typescript-eslint/types": "8.62.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "WinApp extension for Visual Studio Code to assist in building, debugging, and packaging Windows applications using the WinAppCLI.",
   "publisher": "Microsoft-WinAppCLI",
   "icon": "images/icon.png",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/WinAppVSCE.git"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "WinApp extension for Visual Studio Code to assist in building, debugging, and packaging Windows applications using the WinAppCLI.",
   "publisher": "Microsoft-WinAppCLI",
   "icon": "images/icon.png",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/WinAppVSCE.git"


### PR DESCRIPTION
Bumps the dev version on main to 0.2.2.

The 0.2.1 release ships from vsc-rel/v0.2.1 (0.2.0 was consumed by a failed manual Marketplace upload), so main stays one patch ahead.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>