### PR TITLE
Fix VSC publish: install vsce from authenticated Azure Artifacts feed

### DIFF
--- a/.pipelines/release-vsc.yml
+++ b/.pipelines/release-vsc.yml
@@ -232,7 +232,14 @@ extends:
               scriptType: bash
               scriptLocation: inlineScript
               inlineScript: |
-                npm install -g @vscode/vsce@3
+                # Install vsce from the authenticated Azure Artifacts feed.
+                # The 1ES pool blocks public npmjs egress, so a plain global install
+                # falls back to the public registry and fails with EACCES. Pin the
+                # registry to the private feed and point npm at the authenticated
+                # .npmrc so vsce + its transitive deps resolve through the proxy.
+                npm install -g @vscode/vsce@3 \
+                  --registry=https://pkgs.dev.azure.com/microsoft/pde-oss/_packaging/winapp-npm-feed/npm/registry/ \
+                  --userconfig "$(System.DefaultWorkingDirectory)/.npmrc"
 
                 VSIX=$(find "$(Pipeline.Workspace)/vscode-extension/" -name "*.vsix" | head -1)
                 if [ -z "$VSIX" ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "winapp",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "winapp",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.9",
         "glob": "^13.0.6"
@@ -1566,6 +1566,7 @@
       "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.0",
         "@typescript-eslint/types": "8.62.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "winapp",
   "displayName": "WinApp",
   "description": "WinApp extension for Visual Studio Code to assist in building, debugging, and packaging Windows applications using the WinAppCLI.",
-  "publisher": "Microsoft DevLabs",
+  "publisher": "Microsoft-WinAppCLI",
   "icon": "images/icon.png",
   "version": "0.2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "winapp",
   "displayName": "WinApp",
   "description": "WinApp extension for Visual Studio Code to assist in building, debugging, and packaging Windows applications using the WinAppCLI.",
-  "publisher": "Microsoft-WinAppCLI",
+  "publisher": "Microsoft DevLabs",
   "icon": "images/icon.png",
   "version": "0.2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "WinApp extension for Visual Studio Code to assist in building, debugging, and packaging Windows applications using the WinAppCLI.",
   "publisher": "Microsoft-WinAppCLI",
   "icon": "images/icon.png",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/WinAppVSCE.git"


### PR DESCRIPTION
## Problem
The `Release_VSC` publish job failed with `vsce: command not found` (exit 127). Root cause: `npm install -g @vscode/vsce@3` resolved against the **public** npm registry, which the 1ES build pool blocks (egress firewall sinkholes the host to TEST-NET `192.0.2.x` → `EACCES` on connect). vsce was never installed, so the subsequent `vsce publish` couldn't run.

The Build job works because it runs `npm ci` against the authenticated private `winapp-npm-feed`; the publish job's global install wasn't going through that feed.

## Fix
Pin the global vsce install to the private Azure Artifacts feed and point npm at the authenticated `.npmrc` (already created + authenticated earlier in the job) so vsce and its transitive deps resolve through the feed's proxy instead of public npmjs.

## Note
This relies on `winapp-npm-feed` having an **npmjs.org upstream source** so it can server-side-proxy `@vscode/vsce@3` and its dependencies. If publishing still fails on resolution, confirm/add that upstream source on the feed.