### PR TITLE
Add VS Code publisher signing and authenticated vsce publish to release pipeline

### DIFF
--- a/.pipelines/release-vsc.yml
+++ b/.pipelines/release-vsc.yml
@@ -29,6 +29,8 @@ parameters:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive, CfsClean
     sdl:
       policheck:
         enabled: true
@@ -175,11 +177,62 @@ extends:
                           "ToolVersion": "1.0"
                       }
                   ]
+          - task: PowerShell@2
+            displayName: Generate extension manifest for publisher signing
+            inputs:
+              pwsh: true
+              targetType: inline
+              workingDirectory: '$(System.DefaultWorkingDirectory)'
+              script: |
+                $artifactsDir = "$(System.DefaultWorkingDirectory)/artifacts"
+                $vsix = Get-ChildItem -Path $artifactsDir -Filter "winapp-*.vsix" |
+                    Sort-Object LastWriteTime -Descending | Select-Object -First 1
+                if (-not $vsix) {
+                    Write-Error "No VSIX found in $artifactsDir"
+                    exit 1
+                }
+                Write-Host "Generating publisher manifest for $($vsix.Name)"
+                # Uses the @vscode/vsce devDependency installed by package-vsc.ps1 (offline, no public registry)
+                npx vsce generate-manifest -i "$($vsix.FullName)" -o "$artifactsDir/extension.manifest"
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Error "vsce generate-manifest failed"
+                    exit 1
+                }
+                # ESRP signs this file in place to produce the publisher signature
+                Copy-Item "$artifactsDir/extension.manifest" "$artifactsDir/extension.signature.p7s" -Force
+                Write-Host "Created extension.manifest and extension.signature.p7s"
+          - ${{ if eq(parameters.DoEsrp, 'true') }}:
+            - task: EsrpCodeSigning@6
+              displayName: Code Sign ESRP - VS Code Publisher Signature
+              inputs:
+                ConnectedServiceName: $(SigningServiceName)
+                AppRegistrationClientId: $(SigningAppId)
+                AppRegistrationTenantId: $(SigningTenantId)
+                AuthAKVName: $(SigningAKVName)
+                AuthCertName: $(SigningAuthCertName)
+                AuthSignCertName: $(SigningSignCertName)
+                FolderPath: '$(System.DefaultWorkingDirectory)/artifacts/'
+                Pattern: 'extension.signature.p7s'
+                UseMinimatch: true
+                signConfigType: inlineSignParams
+                inlineOperation: |
+                  [
+                      {
+                          "KeyCode": "CP-401405",
+                          "OperationCode": "VSCodePublisherSign",
+                          "Parameters": {},
+                          "ToolName": "sign",
+                          "ToolVersion": "1.0"
+                      }
+                  ]
           - task: CopyFiles@2
             displayName: Copy Artifacts - VS Code Extension
             inputs:
               sourceFolder: '$(System.DefaultWorkingDirectory)/artifacts/'
-              contents: '*.vsix'
+              contents: |
+                *.vsix
+                extension.manifest
+                extension.signature.p7s
               targetFolder: '$(Build.ArtifactStagingDirectory)/vscode-extension'
           - task: 1ES.PublishPipelineArtifact@1
             displayName: Upload Artifact - VS Code Extension
@@ -232,14 +285,28 @@ extends:
               scriptType: bash
               scriptLocation: inlineScript
               inlineScript: |
-                npm install -g @vscode/vsce@3
+                # Install vsce from the authenticated Azure Artifacts feed.
+                # The 1ES pool blocks public npmjs egress, so a plain global install
+                # falls back to the public registry and fails with EACCES. Pin the
+                # registry to the private feed and point npm at the authenticated
+                # .npmrc so vsce + its transitive deps resolve through the proxy.
+                npm install -g @vscode/vsce@3 \
+                  --registry=https://pkgs.dev.azure.com/microsoft/pde-oss/_packaging/winapp-npm-feed/npm/registry/ \
+                  --userconfig "$(System.DefaultWorkingDirectory)/.npmrc"
 
                 VSIX=$(find "$(Pipeline.Workspace)/vscode-extension/" -name "*.vsix" | head -1)
+                MANIFEST=$(find "$(Pipeline.Workspace)/vscode-extension/" -name "extension.manifest" | head -1)
+                SIGNATURE=$(find "$(Pipeline.Workspace)/vscode-extension/" -name "extension.signature.p7s" | head -1)
                 if [ -z "$VSIX" ]; then
                   echo "##[error]No VSIX file found in vscode-extension artifact"
                   exit 1
                 fi
+                if [ -z "$MANIFEST" ] || [ -z "$SIGNATURE" ]; then
+                  echo "##[error]No publisher manifest/signature found in vscode-extension artifact"
+                  exit 1
+                fi
 
-                echo "Publishing $VSIX to VS Code Marketplace..."
-                vsce publish --packagePath "$VSIX" --azure-credential
+                echo "Publishing $VSIX to VS Code Marketplace with publisher signature..."
+
+                vsce publish --packagePath "$VSIX" --manifestPath "$MANIFEST" --signaturePath "$SIGNATURE" --azure-credential
 


### PR DESCRIPTION
## Summary
Cherry-picks the release pipeline improvements developed on `vsc-rel/v0.2.1` back to `main`. Scoped strictly to `.pipelines/release-vsc.yml` — it **excludes** the temporary diagnostics and the checkout test pipeline that were added during the egress investigation, and does **not** include the extension version bump.

## What's included
- **Network policy:** set `networkIsolationPolicy: Permissive, CfsClean` on the 1ES pipeline template so the ExDShared pool can perform checkout/egress.
- **VS Code publisher signing:** new step to `vsce generate-manifest`, then ESRP-sign it (`VSCodePublisherSign`) to produce the publisher signature; the `extension.manifest` and `extension.signature.p7s` are added to the published artifact.
- **Authenticated vsce publish:** install `@vscode/vsce@3` from the authenticated Azure Artifacts feed (the 1ES pool blocks public npmjs egress) and publish with `--manifestPath` / `--signaturePath`.

## What's intentionally excluded
- The pre-checkout github.com **network diagnostic** step.
- The **Marketplace identity `az rest` diagnostic** block before `vsce publish`.
- `.pipelines/checkout-test.yml` (the checkout test pipeline).
- The `0.1.1 → 0.2.1` version bump (pipeline-only change, per request).

## Testing
Config-only change to an Azure DevOps pipeline YAML; validated by diffing against the source branch to confirm only the intended hunks are present.
