### PR TITLE
Don't orphan the winapp run process when debug teardown races

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -338,23 +338,42 @@ class WinAppDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory 
 				debugConfiguration.processId = processId;
 			}
 
-			// Start the real debug session as a child of the winapp session
-			await vscode.debug.startDebugging(folder, debugConfiguration, { parentSession: session });
-
-			// When the child debug session ends, kill the winapp run process and stop the parent session
 			const parentSession = session;
+
+			// Tear down exactly once, whichever side finishes first: the child debug
+			// session ending or the winapp run process exiting. Killing the run
+			// process here prevents it from being orphaned in the background.
+			let teardownRequested = false;
+			const teardown = () => {
+				if (teardownRequested) {
+					return;
+				}
+				teardownRequested = true;
+				disposable.dispose();
+				runProcess.kill();
+				vscode.debug.stopDebugging(parentSession);
+			};
+
+			// When the child debug session ends, tear down the run process and parent session
 			const disposable = vscode.debug.onDidTerminateDebugSession((ended) => {
 				if (ended.parentSession === parentSession) {
-					disposable.dispose();
-					runProcess.kill();
-					vscode.debug.stopDebugging(parentSession);
+					teardown();
 				}
 			});
 
 			// When the winapp run process exits (app closed), stop the debug session
 			runProcess.on('close', () => {
-				vscode.debug.stopDebugging(parentSession);
+				teardown();
 			});
+
+			// Start the real debug session as a child of the winapp session. If it
+			// throws, tear down so the winapp run process is not left orphaned.
+			try {
+				await vscode.debug.startDebugging(folder, debugConfiguration, { parentSession: session });
+			} catch (startError) {
+				teardown();
+				throw startError;
+			}
 
 			// Return an inline no-op adapter — the real debugging happens in the child session above
 			return new vscode.DebugAdapterInlineImplementation(new NoOpDebugAdapter());


### PR DESCRIPTION
## What

Harden the WinApp debug adapter factory so the `winapp run` process it spawns is never left orphaned in the background, and the parent debug session is never stopped twice.

## Why

The factory launches the app with `winapp run` and then starts a child debug session that attaches to it. Two teardown races existed:

1. **Leak on `startDebugging` throw** — if starting the child session threw, the outer `catch` rethrew without killing the spawned `runProcess`, leaving a background process running after the failed debug attempt.
2. **Double stop** — both `onDidTerminateDebugSession` and `runProcess.on('close')` could call `stopDebugging` for the same parent session.

## How

- Consolidate cleanup into a single idempotent `teardown()` that disposes the terminate listener, kills the run process, and stops the parent session **at most once** (guarded by a `teardownRequested` flag).
- Wrap `startDebugging` in a try/catch that runs `teardown()` before rethrowing, so a failed attach never orphans the run process.

## Scope

This is a self-contained teardown-hardening bugfix, independent of #32. It touches the same debug-adapter region as PR #55, so a light rebase may be needed depending on merge order.

## Testing

- `npm run compile-tsc` — clean
- `npm run lint` — 0 errors (8 pre-existing warnings)
