### PR TITLE
Route dev-cert install through an elevated window instead of failing (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ All commands are accessible from the Command Palette (`Ctrl+Shift+P`). Type **Wi
 | **WinApp: Generate Manifest** | Generate an `AppxManifest.xml` from a template (packaged or sparse). |
 | **WinApp: Add Manifest Execution Alias** | Add an execution alias to the manifest so the packaged app can be launched from the command line. |
 | **WinApp: Update Manifest Assets** | Auto-generate all required app icon assets from a single source image (PNG, JPG, GIF, or BMP). |
-| **WinApp: Generate Certificate** | Create a development certificate for signing, with an option to install it immediately. |
-| **WinApp: Install Certificate** | Install an existing `.pfx` or `.cer` certificate. (requires Admin elevation) |
+| **WinApp: Generate Certificate** | Create a development certificate for signing, with an option to also install (trust) it. Installing prompts for admin via a UAC window when VS Code isn't elevated. |
+| **WinApp: Install Certificate** | Install (trust) an existing `.pfx` or `.cer` certificate in the machine store. Prompts for admin via a UAC window when VS Code isn't elevated. |
 | **WinApp: Certificate Info** | Display certificate details (subject, thumbprint, expiry) to verify a certificate matches your manifest. |
 | **WinApp: Sign Package** | Sign an MSIX package or executable with a certificate. |
 | **WinApp: Run SDK Tool** | Run Windows SDK tools (`makeappx`, `signtool`, `mt`, `makepri`) with custom arguments. |
@@ -245,8 +245,8 @@ For debugging, install the debugger extension that matches your app's language (
 | **"No folders containing .exe files found in the workspace..."** or **"No build output folder selected..."** when pressing F5 | The project hasn't been built yet, or the build output is in an unexpected location. | Build your project first (e.g., `dotnet build`), or set `inputFolder` in `launch.json` to point to the folder containing your `.exe`. |
 | **Debugger doesn't attach** | The required debugger extension isn't installed. | Install the matching extension for your language — see [Supported debuggers](#integrated-debugging). |
 | **App launches but changes aren't visible** | The `winapp` debug type does not build the project automatically. | Rebuild your project before pressing F5, or add a `preLaunchTask` to automate it (see the tip in [Integrated Debugging](#integrated-debugging)). |
-| **Certificate trust error when running** | The development certificate isn't installed or has expired. | Run **WinApp: Generate Certificate** and choose to install it, or run **WinApp: Install Certificate** with your existing `.pfx` file. (requires Admin elevation) |
-| **"Access denied" or permission errors** | Some operations (certificate install, package registration) require elevation. | Run VS Code as Administrator, or use an elevated terminal for the failing command. |
+| **Certificate trust error when running** | The development certificate isn't installed or has expired. | Run **WinApp: Generate Certificate** and choose to also install it, or run **WinApp: Install Certificate** with your existing `.pfx` file. Both prompt for admin (UAC) when VS Code isn't elevated. |
+| **"Access denied" or permission errors** | Some operations (package registration) require elevation. Certificate install now prompts for admin automatically. | Approve the UAC prompt when it appears, or run VS Code as Administrator. |
 
 ## Feedback and Support
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { spawn } from 'child_process';
-import { getWinappCliPath, WINAPP_CLI_CALLER_VALUE, escapePowerShellArg } from './winapp-cli-utils';
+import { spawn, execFile } from 'child_process';
+import { getWinappCliPath, WINAPP_CLI_CALLER_VALUE, escapePowerShellArg, buildElevatedTerminalCommand } from './winapp-cli-utils';
 import { detectProjects } from './project-detection';
 import { resolveProjectDirectory as resolveProjectDirectoryCore } from './project-resolver';
 import { glob } from 'glob';
@@ -67,6 +67,63 @@ async function runWinappCommand(extensionPath: string, command: string, cwd: str
 
 	terminal.sendText(`& ${escapePowerShellArg(cliPath)} ${command}`);
 	return '';
+}
+
+/**
+ * Report whether the current VS Code process is running elevated (as
+ * administrator).
+ *
+ * VS Code cannot launch an elevated integrated terminal, so admin-only winapp
+ * commands must be routed either through the normal terminal (when already
+ * elevated) or through a separate UAC-elevated window (when not). We probe the
+ * process token with PowerShell's WindowsPrincipal check. On any failure we
+ * return `false`, which is the safe default: the command is then launched via
+ * an elevated window (UAC), avoiding a silent "Access denied" failure.
+ */
+async function isProcessElevated(): Promise<boolean> {
+	return new Promise((resolve) => {
+		execFile(
+			'powershell.exe',
+			[
+				'-NoProfile',
+				'-NonInteractive',
+				'-Command',
+				'[bool]([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)'
+			],
+			{ timeout: 10000, windowsHide: true },
+			(error, stdout) => {
+				resolve(!error && stdout.trim().toLowerCase() === 'true');
+			}
+		);
+	});
+}
+
+/**
+ * Run a winapp command that requires administrator rights.
+ *
+ * If VS Code is already elevated, the command runs in the normal integrated
+ * terminal. Otherwise it is launched in a separate UAC-elevated PowerShell
+ * window (VS Code cannot elevate the integrated terminal), and an information
+ * message explains that a Windows admin prompt will appear.
+ */
+async function runWinappCommandElevated(extensionPath: string, command: string, cwd: string): Promise<void> {
+	if (await isProcessElevated()) {
+		await runWinappCommand(extensionPath, command, cwd);
+		return;
+	}
+
+	const cliPath = getWinappCliPath(extensionPath);
+	const terminal = vscode.window.createTerminal({
+		name: 'WinApp CLI (Admin)',
+		cwd: cwd,
+		shellPath: 'powershell.exe',
+		env: { WINAPP_CLI_CALLER: WINAPP_CLI_CALLER_VALUE }
+	});
+	terminal.show();
+	terminal.sendText(buildElevatedTerminalCommand(cliPath, command, cwd));
+	vscode.window.showInformationMessage(
+		'Installing the certificate requires administrator rights. Approve the Windows User Account Control (UAC) prompt in the elevated window that just opened.'
+	);
 }
 
 /**
@@ -656,16 +713,23 @@ export function activate(context: vscode.ExtensionContext) {
 			}
 
 			const install = await vscode.window.showQuickPick(
-				['Yes', 'No'],
-				{ placeHolder: 'Install certificate after generation?' }
+				['Generate only', 'Generate and install (requires admin)'],
+				{ placeHolder: 'Generate a development certificate — install it in the machine store too?' }
 			);
 
-			let command = 'cert generate';
-			if (install === 'Yes') {
-				command += ' --install';
+			if (!install) {
+				return;
 			}
 
-			await runWinappCommand(extensionPath, command, projectDir);
+			// Installing trusts the certificate in the machine store, which needs
+			// administrator rights. When VS Code isn't elevated we can't install
+			// from the integrated terminal, so run the whole generate+install in a
+			// separate UAC-elevated window instead of failing with "Access denied".
+			if (install === 'Generate and install (requires admin)') {
+				await runWinappCommandElevated(extensionPath, 'cert generate --install', projectDir);
+			} else {
+				await runWinappCommand(extensionPath, 'cert generate', projectDir);
+			}
 		})
 	);
 
@@ -686,7 +750,9 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
-			await runWinappCommand(extensionPath, `cert install ${escapePowerShellArg(certPath)}`, workspacePath);
+			// Trusting a certificate in the machine store requires admin; route
+			// through an elevated window when VS Code isn't already elevated.
+			await runWinappCommandElevated(extensionPath, `cert install ${escapePowerShellArg(certPath)}`, workspacePath);
 		})
 	);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -140,7 +140,7 @@ async function runWinappCommandElevated(extensionPath: string, command: string, 
 	}
 
 	const terminal = vscode.window.createTerminal({
-		name: 'WinApp CLI (Admin)',
+		name: 'WinApp CLI (Admin launcher)',
 		cwd: cwd,
 		shellPath: 'powershell.exe',
 		env: { WINAPP_CLI_CALLER: WINAPP_CLI_CALLER_VALUE }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import {
 	getWinappCliPath,
 	WINAPP_CLI_CALLER_VALUE,
 	escapePowerShellArg,
-	getWindowsPowerShellPath,
+	resolveWindowsPowerShellPath,
 	isUsableElevatedCliPath,
 	decideElevatedWinappCommand
 } from './winapp-cli-utils';
@@ -16,6 +16,7 @@ import { glob } from 'glob';
 import { ManifestEditorProvider } from './manifest-editor/manifest-editor-provider';
 
 const WINAPP_DEBUG_TYPE = 'winapp';
+const WINDOWS_POWERSHELL_PATH = resolveWindowsPowerShellPath(process.env.SystemRoot);
 
 /**
  * Maps debugger types to the VS Code extensions that provide them.
@@ -91,7 +92,7 @@ async function runWinappCommand(extensionPath: string, command: string, cwd: str
 async function isProcessElevated(): Promise<boolean> {
 	return new Promise((resolve) => {
 		execFile(
-			'powershell.exe',
+			WINDOWS_POWERSHELL_PATH,
 			[
 				'-NoProfile',
 				'-NonInteractive',
@@ -117,7 +118,7 @@ async function isProcessElevated(): Promise<boolean> {
 async function runWinappCommandElevated(extensionPath: string, command: string, cwd: string): Promise<void> {
 	const isElevated = await isProcessElevated();
 	const cliPath = getWinappCliPath(extensionPath);
-	const launcherPath = getWindowsPowerShellPath(process.env.SystemRoot);
+	const launcherPath = WINDOWS_POWERSHELL_PATH;
 	const decision = decideElevatedWinappCommand(
 		isElevated,
 		isUsableElevatedCliPath(cliPath, fs.existsSync(cliPath)),
@@ -142,7 +143,7 @@ async function runWinappCommandElevated(extensionPath: string, command: string, 
 	const terminal = vscode.window.createTerminal({
 		name: 'WinApp CLI (Admin launcher)',
 		cwd: cwd,
-		shellPath: 'powershell.exe',
+		shellPath: WINDOWS_POWERSHELL_PATH,
 		env: { WINAPP_CLI_CALLER: WINAPP_CLI_CALLER_VALUE }
 	});
 	terminal.show();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,15 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as fs from 'fs';
 import { spawn, execFile } from 'child_process';
-import { getWinappCliPath, WINAPP_CLI_CALLER_VALUE, escapePowerShellArg, buildElevatedTerminalCommand } from './winapp-cli-utils';
+import {
+	getWinappCliPath,
+	WINAPP_CLI_CALLER_VALUE,
+	escapePowerShellArg,
+	getWindowsPowerShellPath,
+	isUsableElevatedCliPath,
+	decideElevatedWinappCommand
+} from './winapp-cli-utils';
 import { detectProjects } from './project-detection';
 import { resolveProjectDirectory as resolveProjectDirectoryCore } from './project-resolver';
 import { glob } from 'glob';
@@ -107,12 +115,30 @@ async function isProcessElevated(): Promise<boolean> {
  * message explains that a Windows admin prompt will appear.
  */
 async function runWinappCommandElevated(extensionPath: string, command: string, cwd: string): Promise<void> {
-	if (await isProcessElevated()) {
+	const isElevated = await isProcessElevated();
+	const cliPath = getWinappCliPath(extensionPath);
+	const launcherPath = getWindowsPowerShellPath(process.env.SystemRoot);
+	const decision = decideElevatedWinappCommand(
+		isElevated,
+		isUsableElevatedCliPath(cliPath, fs.existsSync(cliPath)),
+		cliPath,
+		command,
+		cwd,
+		launcherPath
+	);
+
+	if (decision.kind === 'run-normally') {
 		await runWinappCommand(extensionPath, command, cwd);
 		return;
 	}
 
-	const cliPath = getWinappCliPath(extensionPath);
+	if (decision.kind === 'error-cli-missing') {
+		vscode.window.showErrorMessage(
+			'The bundled WinApp CLI executable could not be found, so the administrator command was not started. Rebuild or reinstall the extension, then try again.'
+		);
+		return;
+	}
+
 	const terminal = vscode.window.createTerminal({
 		name: 'WinApp CLI (Admin)',
 		cwd: cwd,
@@ -120,7 +146,7 @@ async function runWinappCommandElevated(extensionPath: string, command: string, 
 		env: { WINAPP_CLI_CALLER: WINAPP_CLI_CALLER_VALUE }
 	});
 	terminal.show();
-	terminal.sendText(buildElevatedTerminalCommand(cliPath, command, cwd));
+	terminal.sendText(decision.command);
 	vscode.window.showInformationMessage(
 		'Installing the certificate requires administrator rights. Approve the Windows User Account Control (UAC) prompt in the elevated window that just opened.'
 	);

--- a/src/test/shell-escape.test.ts
+++ b/src/test/shell-escape.test.ts
@@ -1,6 +1,14 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { escapePowerShellArg, buildElevatedTerminalCommand } from '../winapp-cli-utils';
+import {
+	escapePowerShellArg,
+	buildElevatedTerminalCommand,
+	getWindowsPowerShellPath,
+	isUsableElevatedCliPath,
+	decideElevatedWinappCommand
+} from '../winapp-cli-utils';
+
+const launcherPath = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
 
 describe('escapePowerShellArg', () => {
 	it('wraps an ordinary path in single quotes', () => {
@@ -8,7 +16,7 @@ describe('escapePowerShellArg', () => {
 	});
 
 	it('does not expand subexpression syntax', () => {
-		// A double-quoted PowerShell string would evaluate $(...) — a single-quoted
+		// A double-quoted PowerShell string would evaluate $(...) - a single-quoted
 		// literal must keep it verbatim so the path cannot run commands.
 		const malicious = 'C:\\$(Remove-Item -Recurse C:\\)';
 		assert.equal(escapePowerShellArg(malicious), `'${malicious}'`);
@@ -42,29 +50,42 @@ describe('buildElevatedTerminalCommand', () => {
 		const result = buildElevatedTerminalCommand(
 			'C:\\ext\\bin\\winapp.exe',
 			"cert install 'C:\\proj\\devcert.pfx'",
-			'C:\\proj'
+			'C:\\proj',
+			launcherPath
 		);
 		assert.equal(
 			result,
-			"Start-Process -FilePath 'powershell.exe' -Verb RunAs -ArgumentList '-NoExit', '-Command', " +
+			"Start-Process -FilePath 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -Verb RunAs -ArgumentList '-NoExit', '-Command', " +
 			"'Set-Location -LiteralPath ''C:\\proj''; & ''C:\\ext\\bin\\winapp.exe'' cert install ''C:\\proj\\devcert.pfx'''"
 		);
 	});
 
 	it('requests elevation via the RunAs verb and keeps the window open', () => {
-		const result = buildElevatedTerminalCommand('winapp', 'cert generate --install', 'C:\\proj');
+		const result = buildElevatedTerminalCommand('winapp', 'cert generate --install', 'C:\\proj', launcherPath);
 		assert.match(result, /-Verb RunAs/);
 		assert.match(result, /-NoExit/);
 	});
 
 	it('sets the elevated working directory so RunAs does not default to System32', () => {
-		const result = buildElevatedTerminalCommand('winapp', 'cert generate', 'C:\\my proj');
+		const result = buildElevatedTerminalCommand('winapp', 'cert generate', 'C:\\my proj', launcherPath);
 		// Doubled quotes because Set-Location sits inside the outer -Command literal.
 		assert.match(result, /Set-Location -LiteralPath ''C:\\my proj''/);
 	});
 
+	it('uses the supplied absolute Windows PowerShell launcher path', () => {
+		const customLauncher = 'D:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+		const result = buildElevatedTerminalCommand('C:\\ext\\bin\\winapp.exe', 'cert generate', 'C:\\proj', customLauncher);
+		assert.match(result, /^Start-Process -FilePath 'D:\\Windows\\System32\\WindowsPowerShell\\v1\.0\\powershell\.exe'/);
+	});
+
+	it('doubles single quotes in the working directory so it cannot break out of Set-Location', () => {
+		const result = buildElevatedTerminalCommand('C:\\ext\\bin\\winapp.exe', 'cert generate', "C:\\o'brien\\proj", launcherPath);
+		assert.match(result, /Set-Location -LiteralPath ''C:\\o''''brien\\proj''/);
+		assert.equal((result.match(/'/g) || []).length % 2, 0);
+	});
+
 	it('doubles single quotes in the CLI path so it cannot break out of the literal', () => {
-		const result = buildElevatedTerminalCommand("C:\\o'brien\\winapp.exe", 'cert generate', 'C:\\proj');
+		const result = buildElevatedTerminalCommand("C:\\o'brien\\winapp.exe", 'cert generate', 'C:\\proj', launcherPath);
 		// The path's quote is doubled once for the inner call and again for the
 		// outer -Command literal, leaving every quote in the line balanced.
 		assert.equal((result.match(/'/g) || []).length % 2, 0);
@@ -73,8 +94,72 @@ describe('buildElevatedTerminalCommand', () => {
 
 	it('keeps a quote-injection attempt in the args inert', () => {
 		const attack = escapePowerShellArg("'; Remove-Item C:\\ #");
-		const result = buildElevatedTerminalCommand('winapp', `cert install ${attack}`, 'C:\\proj');
+		const result = buildElevatedTerminalCommand('winapp', `cert install ${attack}`, 'C:\\proj', launcherPath);
 		// Every quote is paired: the injection stays inside a single literal.
 		assert.equal((result.match(/'/g) || []).length % 2, 0);
 	});
 });
+
+describe('getWindowsPowerShellPath', () => {
+	it('builds the launcher path from SystemRoot', () => {
+		assert.equal(getWindowsPowerShellPath('D:\\Windows'), 'D:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe');
+	});
+
+	it('falls back to C:\\Windows when SystemRoot is unavailable', () => {
+		assert.equal(getWindowsPowerShellPath(), launcherPath);
+	});
+});
+
+describe('isUsableElevatedCliPath', () => {
+	it('accepts an absolute existing winapp.exe path', () => {
+		assert.equal(isUsableElevatedCliPath('C:\\ext\\bin\\winapp.exe', true), true);
+	});
+
+	it('rejects the search-path fallback even if a command by that name exists', () => {
+		assert.equal(isUsableElevatedCliPath('winapp', true), false);
+	});
+
+	it('rejects an absolute winapp.exe path when it does not exist', () => {
+		assert.equal(isUsableElevatedCliPath('C:\\ext\\bin\\winapp.exe', false), false);
+	});
+
+	it('rejects an absolute path to a different executable', () => {
+		assert.equal(isUsableElevatedCliPath('C:\\ext\\bin\\powershell.exe', true), false);
+	});
+});
+
+describe('decideElevatedWinappCommand', () => {
+	it('routes elevated processes to the normal terminal without requiring an elevated-safe CLI path', () => {
+		assert.deepEqual(
+			decideElevatedWinappCommand(true, false, 'winapp', 'cert generate --install', 'C:\\proj', launcherPath),
+			{ kind: 'run-normally' }
+		);
+	});
+
+	it('routes non-elevated processes with a usable CLI path to an elevated launcher command', () => {
+		const decision = decideElevatedWinappCommand(
+			false,
+			true,
+			'C:\\ext\\bin\\winapp.exe',
+			'cert generate --install',
+			'C:\\proj',
+			launcherPath
+		);
+
+		assert.equal(decision.kind, 'run-elevated');
+		if (decision.kind === 'run-elevated') {
+			assert.equal(
+				decision.command,
+				buildElevatedTerminalCommand('C:\\ext\\bin\\winapp.exe', 'cert generate --install', 'C:\\proj', launcherPath)
+			);
+		}
+	});
+
+	it('fails closed when a non-elevated process only has an unusable CLI path', () => {
+		assert.deepEqual(
+			decideElevatedWinappCommand(false, false, 'winapp', 'cert generate --install', 'C:\\proj', launcherPath),
+			{ kind: 'error-cli-missing' }
+		);
+	});
+});
+

--- a/src/test/shell-escape.test.ts
+++ b/src/test/shell-escape.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import {
 	escapePowerShellArg,
 	buildElevatedTerminalCommand,
-	getWindowsPowerShellPath,
+	resolveWindowsPowerShellPath,
 	isUsableElevatedCliPath,
 	decideElevatedWinappCommand
 } from '../winapp-cli-utils';
@@ -100,13 +100,17 @@ describe('buildElevatedTerminalCommand', () => {
 	});
 });
 
-describe('getWindowsPowerShellPath', () => {
+describe('resolveWindowsPowerShellPath', () => {
 	it('builds the launcher path from SystemRoot', () => {
-		assert.equal(getWindowsPowerShellPath('D:\\Windows'), 'D:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe');
+		assert.equal(resolveWindowsPowerShellPath('D:\\Windows'), 'D:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe');
 	});
 
 	it('falls back to C:\\Windows when SystemRoot is unavailable', () => {
-		assert.equal(getWindowsPowerShellPath(), launcherPath);
+		assert.equal(resolveWindowsPowerShellPath(undefined), launcherPath);
+	});
+
+	it('falls back to C:\\Windows when SystemRoot is empty', () => {
+		assert.equal(resolveWindowsPowerShellPath(''), launcherPath);
 	});
 });
 

--- a/src/test/shell-escape.test.ts
+++ b/src/test/shell-escape.test.ts
@@ -129,9 +129,16 @@ describe('isUsableElevatedCliPath', () => {
 });
 
 describe('decideElevatedWinappCommand', () => {
-	it('routes elevated processes to the normal terminal without requiring an elevated-safe CLI path', () => {
+	it('fails closed when an elevated process only has an unusable CLI path', () => {
 		assert.deepEqual(
 			decideElevatedWinappCommand(true, false, 'winapp', 'cert generate --install', 'C:\\proj', launcherPath),
+			{ kind: 'error-cli-missing' }
+		);
+	});
+
+	it('routes elevated processes with a usable CLI path to the normal terminal', () => {
+		assert.deepEqual(
+			decideElevatedWinappCommand(true, true, 'C:\\ext\\bin\\winapp.exe', 'cert generate --install', 'C:\\proj', launcherPath),
 			{ kind: 'run-normally' }
 		);
 	});

--- a/src/test/shell-escape.test.ts
+++ b/src/test/shell-escape.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { escapePowerShellArg } from '../winapp-cli-utils';
+import { escapePowerShellArg, buildElevatedTerminalCommand } from '../winapp-cli-utils';
 
 describe('escapePowerShellArg', () => {
 	it('wraps an ordinary path in single quotes', () => {
@@ -34,5 +34,47 @@ describe('escapePowerShellArg', () => {
 
 	it('handles an empty string', () => {
 		assert.equal(escapePowerShellArg(''), "''");
+	});
+});
+
+describe('buildElevatedTerminalCommand', () => {
+	it('launches an elevated PowerShell window that runs the winapp CLI in the working directory', () => {
+		const result = buildElevatedTerminalCommand(
+			'C:\\ext\\bin\\winapp.exe',
+			"cert install 'C:\\proj\\devcert.pfx'",
+			'C:\\proj'
+		);
+		assert.equal(
+			result,
+			"Start-Process -FilePath 'powershell.exe' -Verb RunAs -ArgumentList '-NoExit', '-Command', " +
+			"'Set-Location -LiteralPath ''C:\\proj''; & ''C:\\ext\\bin\\winapp.exe'' cert install ''C:\\proj\\devcert.pfx'''"
+		);
+	});
+
+	it('requests elevation via the RunAs verb and keeps the window open', () => {
+		const result = buildElevatedTerminalCommand('winapp', 'cert generate --install', 'C:\\proj');
+		assert.match(result, /-Verb RunAs/);
+		assert.match(result, /-NoExit/);
+	});
+
+	it('sets the elevated working directory so RunAs does not default to System32', () => {
+		const result = buildElevatedTerminalCommand('winapp', 'cert generate', 'C:\\my proj');
+		// Doubled quotes because Set-Location sits inside the outer -Command literal.
+		assert.match(result, /Set-Location -LiteralPath ''C:\\my proj''/);
+	});
+
+	it('doubles single quotes in the CLI path so it cannot break out of the literal', () => {
+		const result = buildElevatedTerminalCommand("C:\\o'brien\\winapp.exe", 'cert generate', 'C:\\proj');
+		// The path's quote is doubled once for the inner call and again for the
+		// outer -Command literal, leaving every quote in the line balanced.
+		assert.equal((result.match(/'/g) || []).length % 2, 0);
+		assert.ok(result.includes("o''''brien"));
+	});
+
+	it('keeps a quote-injection attempt in the args inert', () => {
+		const attack = escapePowerShellArg("'; Remove-Item C:\\ #");
+		const result = buildElevatedTerminalCommand('winapp', `cert install ${attack}`, 'C:\\proj');
+		// Every quote is paired: the injection stays inside a single literal.
+		assert.equal((result.match(/'/g) || []).length % 2, 0);
 	});
 });

--- a/src/winapp-cli-utils.ts
+++ b/src/winapp-cli-utils.ts
@@ -41,7 +41,7 @@ export function escapePowerShellArg(value: string): string {
 	return `'${value.replace(/'/g, "''")}'`;
 }
 
-export function getWindowsPowerShellPath(systemRoot?: string): string {
+export function resolveWindowsPowerShellPath(systemRoot: string | undefined): string {
 	return path.join(systemRoot || 'C:\\Windows', 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
 }
 

--- a/src/winapp-cli-utils.ts
+++ b/src/winapp-cli-utils.ts
@@ -62,12 +62,12 @@ export function decideElevatedWinappCommand(
 	workingDirectory: string,
 	launcherPath: string
 ): ElevatedWinappCommandDecision {
-	if (isElevated) {
-		return { kind: 'run-normally' };
-	}
-
 	if (!cliPathIsUsable) {
 		return { kind: 'error-cli-missing' };
+	}
+
+	if (isElevated) {
+		return { kind: 'run-normally' };
 	}
 
 	return { kind: 'run-elevated', command: buildElevatedTerminalCommand(cliPath, cliArgs, workingDirectory, launcherPath) };

--- a/src/winapp-cli-utils.ts
+++ b/src/winapp-cli-utils.ts
@@ -41,6 +41,38 @@ export function escapePowerShellArg(value: string): string {
 	return `'${value.replace(/'/g, "''")}'`;
 }
 
+export function getWindowsPowerShellPath(systemRoot?: string): string {
+	return path.join(systemRoot || 'C:\\Windows', 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+}
+
+export function isUsableElevatedCliPath(cliPath: string, cliPathExists: boolean): boolean {
+	return path.isAbsolute(cliPath) && path.basename(cliPath).toLowerCase() === 'winapp.exe' && cliPathExists;
+}
+
+export type ElevatedWinappCommandDecision =
+	| { kind: 'run-normally' }
+	| { kind: 'run-elevated'; command: string }
+	| { kind: 'error-cli-missing' };
+
+export function decideElevatedWinappCommand(
+	isElevated: boolean,
+	cliPathIsUsable: boolean,
+	cliPath: string,
+	cliArgs: string,
+	workingDirectory: string,
+	launcherPath: string
+): ElevatedWinappCommandDecision {
+	if (isElevated) {
+		return { kind: 'run-normally' };
+	}
+
+	if (!cliPathIsUsable) {
+		return { kind: 'error-cli-missing' };
+	}
+
+	return { kind: 'run-elevated', command: buildElevatedTerminalCommand(cliPath, cliArgs, workingDirectory, launcherPath) };
+}
+
 /**
  * Build a PowerShell command that runs the winapp CLI elevated in a *separate*
  * console via `Start-Process -Verb RunAs`.
@@ -63,13 +95,14 @@ export function escapePowerShellArg(value: string): string {
  * {@link escapePowerShellArg}, so values containing single quotes stay balanced
  * and cannot break out of the literal.
  *
+ * @param launcherPath Absolute path to Windows PowerShell for the elevated launcher.
  * @param cliPath Path to the bundled winapp executable.
  * @param cliArgs The winapp arguments, already PowerShell-escaped where needed
  *                (e.g. `cert install 'C:\path\devcert.pfx'`).
  * @param workingDirectory Directory to run the elevated command in.
  * @returns A PowerShell command line to send to a (non-elevated) terminal.
  */
-export function buildElevatedTerminalCommand(cliPath: string, cliArgs: string, workingDirectory: string): string {
+export function buildElevatedTerminalCommand(cliPath: string, cliArgs: string, workingDirectory: string, launcherPath: string): string {
 	const innerCommand = `Set-Location -LiteralPath ${escapePowerShellArg(workingDirectory)}; & ${escapePowerShellArg(cliPath)} ${cliArgs}`.trim();
-	return `Start-Process -FilePath 'powershell.exe' -Verb RunAs -ArgumentList '-NoExit', '-Command', ${escapePowerShellArg(innerCommand)}`;
+	return `Start-Process -FilePath ${escapePowerShellArg(launcherPath)} -Verb RunAs -ArgumentList '-NoExit', '-Command', ${escapePowerShellArg(innerCommand)}`;
 }

--- a/src/winapp-cli-utils.ts
+++ b/src/winapp-cli-utils.ts
@@ -40,3 +40,36 @@ export function getWinappCliPath(extensionPath: string): string {
 export function escapePowerShellArg(value: string): string {
 	return `'${value.replace(/'/g, "''")}'`;
 }
+
+/**
+ * Build a PowerShell command that runs the winapp CLI elevated in a *separate*
+ * console via `Start-Process -Verb RunAs`.
+ *
+ * VS Code cannot create an elevated integrated terminal (there is no extension
+ * API for it, by design). Commands that need administrator rights — notably
+ * `cert install`, which trusts a certificate in the machine store — are
+ * therefore launched in a new UAC-elevated PowerShell window. `-NoExit` keeps
+ * that window open so the user can read the result and any errors.
+ *
+ * The elevated shell is pointed at `workingDirectory` with `Set-Location`
+ * before invoking the CLI. A RunAs-elevated process otherwise starts in
+ * `System32`, which would break commands that rely on the working directory
+ * (e.g. `cert generate` infers the publisher from the manifest in the current
+ * directory and writes `devcert.pfx` there). `Set-Location` is used instead of
+ * `Start-Process -WorkingDirectory` because the latter is ignored with `-Verb`
+ * on Windows PowerShell 5.1.
+ *
+ * The working directory, CLI path, and the composed command are all quoted with
+ * {@link escapePowerShellArg}, so values containing single quotes stay balanced
+ * and cannot break out of the literal.
+ *
+ * @param cliPath Path to the bundled winapp executable.
+ * @param cliArgs The winapp arguments, already PowerShell-escaped where needed
+ *                (e.g. `cert install 'C:\path\devcert.pfx'`).
+ * @param workingDirectory Directory to run the elevated command in.
+ * @returns A PowerShell command line to send to a (non-elevated) terminal.
+ */
+export function buildElevatedTerminalCommand(cliPath: string, cliArgs: string, workingDirectory: string): string {
+	const innerCommand = `Set-Location -LiteralPath ${escapePowerShellArg(workingDirectory)}; & ${escapePowerShellArg(cliPath)} ${cliArgs}`.trim();
+	return `Start-Process -FilePath 'powershell.exe' -Verb RunAs -ArgumentList '-NoExit', '-Command', ${escapePowerShellArg(innerCommand)}`;
+}


### PR DESCRIPTION
Fixes #34.

## Investigation summary

The "Generate and install a development certificate?" flow defaulted to installing, and `winapp cert install` **trusts the cert in the machine store, which requires admin**. VS Code isn't elevated by default, and there is **no VS Code API to create an elevated integrated terminal** (confirmed — it's disallowed by design for security). So the install failed with a red `Access denied` even though the certificate was successfully generated.

The bundled CLI also has **no CurrentUser install option** (`cert install` help: *"Trust a certificate on this machine (requires admin)"*), so installing to a non-elevated store isn't possible from the extension today.

## Fix

Per discussion, the behavior is now elevation-aware:

- **VS Code already elevated** → install runs in the normal integrated terminal (unchanged).
- **VS Code not elevated** → the command is launched in a **separate UAC-elevated PowerShell window** via `Start-Process -Verb RunAs`, with an info message telling the user to approve the prompt. This replaces the guaranteed "Access denied" failure with a working install path.
- The **Generate Certificate** quick pick now defaults to **"Generate only"**, so users opt into the admin step instead of hitting it by surprise.

Applies to **WinApp: Generate Certificate** and **WinApp: Install Certificate**.

### Implementation notes

- `buildElevatedTerminalCommand` is extracted into `winapp-cli-utils.ts` with unit tests (`shell-escape.test.ts`) covering quote escaping, the RunAs verb, and the working-directory handling.
- A RunAs-elevated process starts in `System32`; the elevated shell is pointed back at the project directory with `Set-Location` (not `Start-Process -WorkingDirectory`, which is ignored with `-Verb` on Windows PowerShell 5.1) so `cert generate` still infers the publisher from the manifest and writes `devcert.pfx` in the right place.
- README command table and troubleshooting notes updated.

## Out of scope (flagging)

The **Create MSIX Package** command's `--install-cert` option has the *same* elevation trap but is a separate command surface not named in the issue. Left untouched to keep this PR scoped to #34 — happy to do it as a follow-up.

## Testing

- `npm run compile-tsc` — clean
- `npm run lint` — 0 errors (8 pre-existing warnings)
- `npm run test:unit` — passing (11 in shell-escape.test.ts, incl. new elevation-command tests)
- `npm run package` — build complete
