### PR TITLE
pack: show a completion notification with Reveal/Sign/Install actions (#62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All commands are accessible from the Command Palette (`Ctrl+Shift+P`). Type **Wi
 | **WinApp: Run Application** | Run your app as a loose-layout packaged application with full package identity — great for testing APIs that require identity. |
 | **WinApp: Create Debug Identity** | Add sparse package identity to an existing executable so you can launch and debug it directly from VS Code with identity. |
 | **WinApp: Unregister Package** | Unregister a sideloaded development package (e.g., one registered via Run or Create Debug Identity). |
-| **WinApp: Create MSIX Package** | Package your application into an MSIX, with options to generate a certificate and bundle the runtime self-contained. |
+| **WinApp: Create MSIX Package** | Package your application into an MSIX, with options to generate a certificate and bundle the runtime self-contained. On completion, a notification names the built package and offers **Reveal in Explorer**, **Sign**, and **Install** actions. |
 | **WinApp: Generate Manifest** | Generate an `AppxManifest.xml` from a template (packaged or sparse). |
 | **WinApp: Add Manifest Execution Alias** | Add an execution alias to the manifest so the packaged app can be launched from the command line. |
 | **WinApp: Update Manifest Assets** | Auto-generate all required app icon assets from a single source image (PNG, JPG, GIF, or BMP). |
@@ -212,7 +212,7 @@ Use **WinApp: Generate Manifest** to create an `Package.appxmanifest` from a tem
 
 ### Package and sign
 
-Use **WinApp: Create MSIX Package** to package your application. Pair it with **WinApp: Generate Certificate** and **WinApp: Sign Package** to produce a signed, ready-to-distribute MSIX. Use **WinApp: Certificate Info** to verify a certificate's details (subject, thumbprint, expiry) before signing.
+Use **WinApp: Create MSIX Package** to package your application. When packaging finishes, a completion notification names the built `.msix` and offers three actions: **Reveal in Explorer** (open the package in File Explorer), **Sign** (sign the just-built package, pre-filling its path), and **Install** (sideload it via `Add-AppxPackage`). Pair it with **WinApp: Generate Certificate** and **WinApp: Sign Package** to produce a signed, ready-to-distribute MSIX. Use **WinApp: Certificate Info** to verify a certificate's details (subject, thumbprint, expiry) before signing.
 
 ### Access Windows SDK tools
 

--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
     "clean": "node -e \"require('fs').rmSync('bin', {recursive: true, force: true}); require('fs').rmSync('out', {recursive: true, force: true}); require('fs').rmSync('dist', {recursive: true, force: true});\"",
     "download-cli": "pwsh -NoProfile -Command \"& ./scripts/download-cli.ps1\"",
     "download-cli:latest": "pwsh -NoProfile -Command \"& ./scripts/download-cli.ps1 -Tag latest\"",
-    "test:unit": "tsc -p ./ && node -e \"require('fs').cpSync('src/test/fixtures','out/test/fixtures',{recursive:true})\" && mocha out/test/project-detection.test.js && npx tsx --test src/test/extension-field-validator.test.ts src/test/extension-templates.test.ts src/test/manifest-edge-cases.test.ts src/test/manifest-parser.test.ts src/test/manifest-validator.test.ts src/test/project-resolver.test.ts src/test/redos-prevention.test.ts src/test/xml-utils.test.ts src/test/shell-escape.test.ts"
+    "test:unit": "tsc -p ./ && node -e \"require('fs').cpSync('src/test/fixtures','out/test/fixtures',{recursive:true})\" && mocha out/test/project-detection.test.js && npx tsx --test src/test/extension-field-validator.test.ts src/test/extension-templates.test.ts src/test/manifest-edge-cases.test.ts src/test/manifest-parser.test.ts src/test/manifest-validator.test.ts src/test/project-resolver.test.ts src/test/redos-prevention.test.ts src/test/xml-utils.test.ts src/test/shell-escape.test.ts src/test/pack-result.test.ts"
   },
   "dependencies": {
     "@xmldom/xmldom": "^0.9.9",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
 import * as path from 'path';
 import { spawn } from 'child_process';
 import { getWinappCliPath, WINAPP_CLI_CALLER_VALUE, escapePowerShellArg } from './winapp-cli-utils';
@@ -7,10 +8,10 @@ import { resolveProjectDirectory as resolveProjectDirectoryCore } from './projec
 import { glob } from 'glob';
 import { ManifestEditorProvider } from './manifest-editor/manifest-editor-provider';
 import {
-	parsePackagedArtifactPath,
-	buildPackSuccessMessage,
-	deriveAppNameFromArtifact,
-	PACK_ACTIONS
+	PACK_ACTIONS,
+	getPackNotificationAction,
+	isArtifactWithinRoot,
+	planPackCompletion
 } from './pack-result';
 
 const WINAPP_DEBUG_TYPE = 'winapp';
@@ -102,7 +103,7 @@ async function runWinappCapture(
 	args: string[],
 	cwd: string,
 	progressTitle: string
-): Promise<{ code: number | null; output: string }> {
+): Promise<{ code: number | null; output: string; cancelled?: boolean }> {
 	const cliPath = getWinappCliPath(extensionPath);
 	const outputChannel = getWinappOutputChannel();
 	outputChannel.appendLine(`> winapp ${args.join(' ')}`);
@@ -111,10 +112,10 @@ async function runWinappCapture(
 		{
 			location: vscode.ProgressLocation.Notification,
 			title: progressTitle,
-			cancellable: false
+			cancellable: true
 		},
-		() =>
-			new Promise<{ code: number | null; output: string }>((resolve) => {
+		(_progress, token) =>
+			new Promise<{ code: number | null; output: string; cancelled?: boolean }>((resolve) => {
 				const child = spawn(cliPath, args, {
 					cwd,
 					env: { ...process.env, WINAPP_CLI_CALLER: WINAPP_CLI_CALLER_VALUE },
@@ -122,6 +123,37 @@ async function runWinappCapture(
 				});
 
 				let output = '';
+				let settled = false;
+				let cancelled = false;
+				const finish = (result: { code: number | null; output: string; cancelled?: boolean }) => {
+					if (!settled) {
+						settled = true;
+						resolve(result);
+					}
+				};
+
+				const cancellation = token.onCancellationRequested(() => {
+					if (cancelled || settled) {
+						return;
+					}
+					cancelled = true;
+					outputChannel.appendLine('\nPackaging cancelled.');
+					if (child.pid) {
+						// On Windows, winapp pack may spawn helper processes; taskkill /t
+						// terminates the whole tree instead of only the direct child.
+						const killer = spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
+							windowsHide: true
+						});
+						killer.on('error', () => child.kill());
+						killer.on('close', (code) => {
+							if (code !== 0) {
+								child.kill();
+							}
+						});
+					} else {
+						child.kill();
+					}
+				});
 
 				child.stdout!.on('data', (data: Buffer) => {
 					const text = data.toString();
@@ -136,12 +168,18 @@ async function runWinappCapture(
 				});
 
 				child.on('error', (err) => {
+					cancellation.dispose();
+					if (cancelled) {
+						finish({ code: null, output, cancelled: true });
+						return;
+					}
 					outputChannel.appendLine(`\nFailed to run winapp: ${err.message}`);
-					resolve({ code: null, output });
+					finish({ code: null, output });
 				});
 
 				child.on('close', (code) => {
-					resolve({ code, output });
+					cancellation.dispose();
+					finish({ code, output, cancelled });
 				});
 			})
 	);
@@ -171,16 +209,13 @@ async function signPackage(
 	}
 
 	if (!filePath) {
-		vscode.window.showErrorMessage('A file to sign is required');
 		return;
 	}
 
 	const certPath = await selectFile('Select signing certificate', {
 		'Certificates': ['pfx']
 	});
-
 	if (!certPath) {
-		vscode.window.showErrorMessage('A certificate file is required');
 		return;
 	}
 
@@ -214,34 +249,46 @@ function installPackage(artifactPath: string, cwd: string): void {
 async function handlePackCompletion(
 	extensionPath: string,
 	workspacePath: string,
-	result: { code: number | null; output: string }
+	inputFolder: string,
+	result: { code: number | null; output: string; cancelled?: boolean }
 ): Promise<void> {
-	const artifactPath = parsePackagedArtifactPath(result.output);
+	const plan = planPackCompletion(result);
+	switch (plan.kind) {
+		case 'cancelled':
+			return;
+		case 'error':
+			getWinappOutputChannel().show();
+			vscode.window.showErrorMessage(plan.message);
+			return;
+	}
 
-	if (result.code !== 0 || !artifactPath) {
+	if (
+		!fs.existsSync(plan.artifactPath) ||
+		(!isArtifactWithinRoot(plan.artifactPath, workspacePath) &&
+			!isArtifactWithinRoot(plan.artifactPath, inputFolder))
+	) {
 		getWinappOutputChannel().show();
-		vscode.window.showErrorMessage(
-			'Packaging failed. See the WinApp output channel for details.'
-		);
+		vscode.window.showErrorMessage('Packaging failed. See the WinApp output channel for details.');
 		return;
 	}
 
-	const appName = deriveAppNameFromArtifact(artifactPath);
-	const message = buildPackSuccessMessage(artifactPath, appName);
-
 	const choice = await vscode.window.showInformationMessage(
-		message,
+		plan.message,
 		PACK_ACTIONS.reveal,
 		PACK_ACTIONS.sign,
 		PACK_ACTIONS.install
 	);
 
-	if (choice === PACK_ACTIONS.reveal) {
-		await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(artifactPath));
-	} else if (choice === PACK_ACTIONS.sign) {
-		await signPackage(extensionPath, workspacePath, artifactPath);
-	} else if (choice === PACK_ACTIONS.install) {
-		installPackage(artifactPath, path.dirname(artifactPath));
+	switch (getPackNotificationAction(choice)) {
+		case 'reveal':
+			await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(plan.artifactPath));
+			break;
+		case 'sign':
+			await signPackage(extensionPath, workspacePath, plan.artifactPath);
+			break;
+		case 'install':
+			installPackage(plan.artifactPath, path.dirname(plan.artifactPath));
+			break;
 	}
 }
 
@@ -734,7 +781,7 @@ export function activate(context: vscode.ExtensionContext) {
 				workspacePath,
 				'Packaging app...'
 			);
-			await handlePackCompletion(extensionPath, workspacePath, result);
+			await handlePackCompletion(extensionPath, workspacePath, inputFolder, result);
 		})
 	);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,12 @@ import { detectProjects } from './project-detection';
 import { resolveProjectDirectory as resolveProjectDirectoryCore } from './project-resolver';
 import { glob } from 'glob';
 import { ManifestEditorProvider } from './manifest-editor/manifest-editor-provider';
+import {
+	parsePackagedArtifactPath,
+	buildPackSuccessMessage,
+	deriveAppNameFromArtifact,
+	PACK_ACTIONS
+} from './pack-result';
 
 const WINAPP_DEBUG_TYPE = 'winapp';
 
@@ -67,6 +73,176 @@ async function runWinappCommand(extensionPath: string, command: string, cwd: str
 
 	terminal.sendText(`& ${escapePowerShellArg(cliPath)} ${command}`);
 	return '';
+}
+
+/**
+ * Shared output channel for capture-based winapp commands (e.g. pack). Created
+ * lazily and reused so repeated runs don't leak channels.
+ */
+let winappOutputChannel: vscode.OutputChannel | undefined;
+
+function getWinappOutputChannel(): vscode.OutputChannel {
+	if (!winappOutputChannel) {
+		winappOutputChannel = vscode.window.createOutputChannel('WinApp');
+	}
+	return winappOutputChannel;
+}
+
+/**
+ * Run a winapp CLI command via `spawn` (shell: false) while capturing its
+ * combined stdout/stderr, streaming it to the WinApp output channel and a
+ * progress notification. Unlike {@link runWinappCommand}, this waits for the
+ * command to finish so callers can inspect the output (e.g. the produced
+ * package path).
+ *
+ * @returns The process exit code and the full captured output.
+ */
+async function runWinappCapture(
+	extensionPath: string,
+	args: string[],
+	cwd: string,
+	progressTitle: string
+): Promise<{ code: number | null; output: string }> {
+	const cliPath = getWinappCliPath(extensionPath);
+	const outputChannel = getWinappOutputChannel();
+	outputChannel.appendLine(`> winapp ${args.join(' ')}`);
+
+	return vscode.window.withProgress(
+		{
+			location: vscode.ProgressLocation.Notification,
+			title: progressTitle,
+			cancellable: false
+		},
+		() =>
+			new Promise<{ code: number | null; output: string }>((resolve) => {
+				const child = spawn(cliPath, args, {
+					cwd,
+					env: { ...process.env, WINAPP_CLI_CALLER: WINAPP_CLI_CALLER_VALUE },
+					shell: false
+				});
+
+				let output = '';
+
+				child.stdout!.on('data', (data: Buffer) => {
+					const text = data.toString();
+					output += text;
+					outputChannel.append(text);
+				});
+
+				child.stderr!.on('data', (data: Buffer) => {
+					const text = data.toString();
+					output += text;
+					outputChannel.append(text);
+				});
+
+				child.on('error', (err) => {
+					outputChannel.appendLine(`\nFailed to run winapp: ${err.message}`);
+					resolve({ code: null, output });
+				});
+
+				child.on('close', (code) => {
+					resolve({ code, output });
+				});
+			})
+	);
+}
+
+/**
+ * Run the code-signing flow for an MSIX/executable. Prompts for the file to
+ * sign (unless one is supplied) and the signing certificate, then invokes
+ * `winapp sign`. Reused by both the `winapp.sign` command and the post-pack
+ * completion notification.
+ *
+ * @param prefilledFilePath When provided, skips the file picker and signs this
+ *   path directly (e.g. the MSIX just produced by pack).
+ */
+async function signPackage(
+	extensionPath: string,
+	workspacePath: string,
+	prefilledFilePath?: string
+): Promise<void> {
+	let filePath = prefilledFilePath;
+	if (!filePath) {
+		filePath = await selectFile('Select file to sign', {
+			'MSIX Packages': ['msix', 'appx'],
+			'Executables': ['exe', 'dll'],
+			'All files': ['*']
+		});
+	}
+
+	if (!filePath) {
+		vscode.window.showErrorMessage('A file to sign is required');
+		return;
+	}
+
+	const certPath = await selectFile('Select signing certificate', {
+		'Certificates': ['pfx']
+	});
+
+	if (!certPath) {
+		vscode.window.showErrorMessage('A certificate file is required');
+		return;
+	}
+
+	await runWinappCommand(
+		extensionPath,
+		`sign ${escapePowerShellArg(filePath)} --cert ${escapePowerShellArg(certPath)}`,
+		workspacePath
+	);
+}
+
+/**
+ * Install (sideload) a packaged MSIX by running `Add-AppxPackage` in a
+ * PowerShell terminal. The package must be signed with a trusted certificate
+ * for installation to succeed; the terminal surfaces any errors to the user.
+ */
+function installPackage(artifactPath: string, cwd: string): void {
+	const terminal = vscode.window.createTerminal({
+		name: 'WinApp Install',
+		cwd,
+		shellPath: 'powershell.exe'
+	});
+	terminal.show();
+	terminal.sendText(`Add-AppxPackage -Path ${escapePowerShellArg(artifactPath)}`);
+}
+
+/**
+ * Surface the result of a pack run. On success, show a completion notification
+ * naming the produced artifact with Reveal / Sign / Install actions. On
+ * failure, direct the user to the WinApp output channel.
+ */
+async function handlePackCompletion(
+	extensionPath: string,
+	workspacePath: string,
+	result: { code: number | null; output: string }
+): Promise<void> {
+	const artifactPath = parsePackagedArtifactPath(result.output);
+
+	if (result.code !== 0 || !artifactPath) {
+		getWinappOutputChannel().show();
+		vscode.window.showErrorMessage(
+			'Packaging failed. See the WinApp output channel for details.'
+		);
+		return;
+	}
+
+	const appName = deriveAppNameFromArtifact(artifactPath);
+	const message = buildPackSuccessMessage(artifactPath, appName);
+
+	const choice = await vscode.window.showInformationMessage(
+		message,
+		PACK_ACTIONS.reveal,
+		PACK_ACTIONS.sign,
+		PACK_ACTIONS.install
+	);
+
+	if (choice === PACK_ACTIONS.reveal) {
+		await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(artifactPath));
+	} else if (choice === PACK_ACTIONS.sign) {
+		await signPackage(extensionPath, workspacePath, artifactPath);
+	} else if (choice === PACK_ACTIONS.install) {
+		installPackage(artifactPath, path.dirname(artifactPath));
+	}
 }
 
 /**
@@ -405,6 +581,9 @@ export function activate(context: vscode.ExtensionContext) {
 	const extensionPath = context.extensionPath;
 	const provider = new WinAppDebugConfigurationProvider(extensionPath);
 
+	// Dispose the shared WinApp output channel when the extension unloads.
+	context.subscriptions.push({ dispose: () => winappOutputChannel?.dispose() });
+
 	context.subscriptions.push(
 		vscode.debug.registerDebugConfigurationProvider(WINAPP_DEBUG_TYPE, provider)
 	);
@@ -539,15 +718,23 @@ export function activate(context: vscode.ExtensionContext) {
 				{ placeHolder: 'Bundle Windows App SDK runtime (self-contained)?' }
 			);
 
-			let command = `pack ${escapePowerShellArg(inputFolder)}`;
+			// Build the argument array for spawn (shell: false) so paths and flags
+			// are passed literally — no PowerShell parsing/escaping required.
+			const args = ['pack', inputFolder];
 			if (generateCert === 'Yes') {
-				command += ' --generate-cert --install-cert';
+				args.push('--generate-cert', '--install-cert');
 			}
 			if (selfContained === 'Yes') {
-				command += ' --self-contained';
+				args.push('--self-contained');
 			}
 
-			await runWinappCommand(extensionPath, command, workspacePath);
+			const result = await runWinappCapture(
+				extensionPath,
+				args,
+				workspacePath,
+				'Packaging app...'
+			);
+			await handlePackCompletion(extensionPath, workspacePath, result);
 		})
 	);
 
@@ -698,27 +885,7 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
-			const filePath = await selectFile('Select file to sign', {
-				'MSIX Packages': ['msix', 'appx'],
-				'Executables': ['exe', 'dll'],
-				'All files': ['*']
-			});
-
-			if (!filePath) {
-				vscode.window.showErrorMessage('A file to sign is required');
-				return;
-			}
-
-			const certPath = await selectFile('Select signing certificate', {
-				'Certificates': ['pfx']
-			});
-
-			if (!certPath) {
-				vscode.window.showErrorMessage('A certificate file is required');
-				return;
-			}
-
-			await runWinappCommand(extensionPath, `sign ${escapePowerShellArg(filePath)} --cert ${escapePowerShellArg(certPath)}`, workspacePath);
+			await signPackage(extensionPath, workspacePath);
 		})
 	);
 

--- a/src/pack-result.ts
+++ b/src/pack-result.ts
@@ -60,8 +60,8 @@ function looksLikeArtifactPath(candidate: string): boolean {
  * ```
  *
  * Strategy:
- * 1. Prefer the text attached to (or following) the "📦 Package:" marker.
- * 2. Fall back to the last line that ends in a known package extension.
+ * Prefer the text attached to (or following) the "📦 Package:" marker,
+ * concatenating consecutive lines to handle Spectre.Console wrapping.
  *
  * @param output Combined stdout (and optionally stderr) captured from the CLI.
  * @returns The trimmed artifact path, or `undefined` if none was found.
@@ -97,36 +97,6 @@ export function parsePackagedArtifactPath(output: string): string | undefined {
 			accumulated += fragment;
 			if (looksLikeArtifactPath(accumulated)) {
 				return accumulated;
-			}
-		}
-	}
-
-	// 2. Fallback: find the last line ending in a known extension, then
-	//    walk backwards to reconstruct a wrapped path.
-	for (let i = lines.length - 1; i >= 0; i--) {
-		const candidate = lines[i].trim();
-		if (candidate.length === 0) {
-			continue;
-		}
-		if (looksLikeArtifactPath(candidate)) {
-			// The whole path might be on this single line.
-			return candidate;
-		}
-		// Check if this line is a trailing extension fragment (e.g. ".msix")
-		// that belongs to the preceding line(s).
-		const lower = candidate.toLowerCase();
-		const isExtFragment = ARTIFACT_EXTENSIONS.some((ext) => ext === lower || ext.endsWith(lower));
-		if (isExtFragment) {
-			let assembled = candidate;
-			for (let k = i - 1; k >= 0; k--) {
-				const prev = lines[k].trim();
-				if (prev.length === 0) {
-					break;
-				}
-				assembled = prev + assembled;
-				if (looksLikeArtifactPath(assembled)) {
-					return assembled;
-				}
 			}
 		}
 	}

--- a/src/pack-result.ts
+++ b/src/pack-result.ts
@@ -15,6 +15,11 @@ export const PACK_ACTIONS = {
 } as const;
 
 export type PackActionLabel = (typeof PACK_ACTIONS)[keyof typeof PACK_ACTIONS];
+export type PackNotificationAction = 'reveal' | 'sign' | 'install' | 'none';
+export type PackCompletionPlan =
+	| { kind: 'cancelled' }
+	| { kind: 'error'; message: string }
+	| { kind: 'success'; artifactPath: string; appName: string | undefined; message: string };
 
 /** File extensions the CLI can emit for a packaged artifact. */
 const ARTIFACT_EXTENSIONS = ['.msixbundle', '.msix', '.appxbundle', '.appx'];
@@ -75,16 +80,15 @@ export function parsePackagedArtifactPath(output: string): string | undefined {
 			return sameLine;
 		}
 
-		// Path wrapped onto the following non-empty line(s).
+		// Path printed on a following value row.
 		for (let j = i + 1; j < lines.length; j++) {
-			const next = lines[j].trim();
-			if (next.length === 0) {
+			const candidate = lines[j].trim();
+			if (candidate.length === 0) {
 				continue;
 			}
-			if (looksLikeArtifactPath(next)) {
-				return next;
+			if (looksLikeArtifactPath(candidate)) {
+				return candidate;
 			}
-			break;
 		}
 	}
 
@@ -117,6 +121,52 @@ export function buildPackSuccessMessage(artifactPath: string, appName?: string):
 	return `Package created → ${fileName}`;
 }
 
+export function getPackNotificationAction(choice: string | undefined): PackNotificationAction {
+	if (choice === PACK_ACTIONS.reveal) {
+		return 'reveal';
+	}
+	if (choice === PACK_ACTIONS.sign) {
+		return 'sign';
+	}
+	if (choice === PACK_ACTIONS.install) {
+		return 'install';
+	}
+	return 'none';
+}
+
+export function isArtifactWithinRoot(artifactPath: string, root: string): boolean {
+	const resolvedArtifact = path.resolve(artifactPath).toLowerCase();
+	const resolvedRoot = path.resolve(root).toLowerCase();
+	const relativePath = path.relative(resolvedRoot, resolvedArtifact);
+	return relativePath.length > 0 && !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
+}
+
+export function planPackCompletion(result: {
+	code: number | null;
+	output: string;
+	cancelled?: boolean;
+}): PackCompletionPlan {
+	if (result.cancelled) {
+		return { kind: 'cancelled' };
+	}
+
+	const artifactPath = parsePackagedArtifactPath(result.output);
+	if (result.code !== 0 || !artifactPath) {
+		return {
+			kind: 'error',
+			message: 'Packaging failed. See the WinApp output channel for details.'
+		};
+	}
+
+	const appName = deriveAppNameFromArtifact(artifactPath);
+	return {
+		kind: 'success',
+		artifactPath,
+		appName,
+		message: buildPackSuccessMessage(artifactPath, appName)
+	};
+}
+
 /**
  * Derive a friendly app name from a packaged artifact's file name.
  *
@@ -138,4 +188,3 @@ export function deriveAppNameFromArtifact(artifactPath: string): string | undefi
 	}
 	return undefined;
 }
-

--- a/src/pack-result.ts
+++ b/src/pack-result.ts
@@ -80,23 +80,54 @@ export function parsePackagedArtifactPath(output: string): string | undefined {
 			return sameLine;
 		}
 
-		// Path printed on a following value row.
+		// Path printed on following row(s). Spectre.Console may wrap a long
+		// path across multiple lines, so we concatenate non-empty lines after
+		// the marker until the accumulated text ends in a known extension.
+		let accumulated = sameLine;
 		for (let j = i + 1; j < lines.length; j++) {
-			const candidate = lines[j].trim();
-			if (candidate.length === 0) {
+			const fragment = lines[j].trim();
+			if (fragment.length === 0) {
+				if (accumulated.length > 0) {
+					// A blank line after content means the path block ended
+					// without matching — stop accumulating.
+					break;
+				}
 				continue;
 			}
-			if (looksLikeArtifactPath(candidate)) {
-				return candidate;
+			accumulated += fragment;
+			if (looksLikeArtifactPath(accumulated)) {
+				return accumulated;
 			}
 		}
 	}
 
-	// 2. Fallback: the last line that looks like a package path wins.
+	// 2. Fallback: find the last line ending in a known extension, then
+	//    walk backwards to reconstruct a wrapped path.
 	for (let i = lines.length - 1; i >= 0; i--) {
 		const candidate = lines[i].trim();
+		if (candidate.length === 0) {
+			continue;
+		}
 		if (looksLikeArtifactPath(candidate)) {
+			// The whole path might be on this single line.
 			return candidate;
+		}
+		// Check if this line is a trailing extension fragment (e.g. ".msix")
+		// that belongs to the preceding line(s).
+		const lower = candidate.toLowerCase();
+		const isExtFragment = ARTIFACT_EXTENSIONS.some((ext) => ext === lower || ext.endsWith(lower));
+		if (isExtFragment) {
+			let assembled = candidate;
+			for (let k = i - 1; k >= 0; k--) {
+				const prev = lines[k].trim();
+				if (prev.length === 0) {
+					break;
+				}
+				assembled = prev + assembled;
+				if (looksLikeArtifactPath(assembled)) {
+					return assembled;
+				}
+			}
 		}
 	}
 

--- a/src/pack-result.ts
+++ b/src/pack-result.ts
@@ -1,0 +1,141 @@
+import * as path from 'path';
+
+/**
+ * Pure helpers for interpreting the output of `winapp package` and building the
+ * post-pack completion notification. These are kept free of the VS Code API so
+ * they can be unit-tested directly (see `src/test/pack-result.test.ts`); the
+ * VS Code-facing wiring lives in `extension.ts`.
+ */
+
+/** Labels for the action buttons shown on the pack completion notification. */
+export const PACK_ACTIONS = {
+	reveal: 'Reveal in Explorer',
+	sign: 'Sign',
+	install: 'Install'
+} as const;
+
+export type PackActionLabel = (typeof PACK_ACTIONS)[keyof typeof PACK_ACTIONS];
+
+/** File extensions the CLI can emit for a packaged artifact. */
+const ARTIFACT_EXTENSIONS = ['.msixbundle', '.msix', '.appxbundle', '.appx'];
+
+/**
+ * Marker the CLI prints immediately before the packaged artifact path.
+ * The path may follow on the same line or wrap onto subsequent lines, so the
+ * parser tolerates both layouts.
+ */
+const PACKAGE_MARKER = '📦 Package:';
+
+function stripMarkers(line: string): string {
+	// Remove the leading "📦 Package:" marker if present, plus surrounding
+	// whitespace, so what remains is the (possibly empty) path fragment.
+	const markerIndex = line.indexOf(PACKAGE_MARKER);
+	if (markerIndex >= 0) {
+		return line.slice(markerIndex + PACKAGE_MARKER.length).trim();
+	}
+	return line.trim();
+}
+
+function looksLikeArtifactPath(candidate: string): boolean {
+	const lower = candidate.toLowerCase();
+	return ARTIFACT_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+/**
+ * Extract the absolute path of the artifact produced by `winapp package` from
+ * its captured stdout.
+ *
+ * The CLI prints the path after a "📦 Package:" marker, but Spectre.Console
+ * wrapping frequently pushes the path onto the line *after* the marker, e.g.:
+ *
+ * ```
+ *   📦 Package:
+ * C:\path\to\CounterApp_1.0.0.0_x64.msix
+ * ✅ MSIX package creation completed.
+ * ```
+ *
+ * Strategy:
+ * 1. Prefer the text attached to (or following) the "📦 Package:" marker.
+ * 2. Fall back to the last line that ends in a known package extension.
+ *
+ * @param output Combined stdout (and optionally stderr) captured from the CLI.
+ * @returns The trimmed artifact path, or `undefined` if none was found.
+ */
+export function parsePackagedArtifactPath(output: string): string | undefined {
+	const lines = output.split(/\r?\n/).map((line) => line.replace(/\r$/, ''));
+
+	// 1. Anchor on the "📦 Package:" marker.
+	for (let i = 0; i < lines.length; i++) {
+		if (!lines[i].includes(PACKAGE_MARKER)) {
+			continue;
+		}
+
+		const sameLine = stripMarkers(lines[i]);
+		if (looksLikeArtifactPath(sameLine)) {
+			return sameLine;
+		}
+
+		// Path wrapped onto the following non-empty line(s).
+		for (let j = i + 1; j < lines.length; j++) {
+			const next = lines[j].trim();
+			if (next.length === 0) {
+				continue;
+			}
+			if (looksLikeArtifactPath(next)) {
+				return next;
+			}
+			break;
+		}
+	}
+
+	// 2. Fallback: the last line that looks like a package path wins.
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const candidate = lines[i].trim();
+		if (looksLikeArtifactPath(candidate)) {
+			return candidate;
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * Build the message shown in the pack completion notification.
+ *
+ * Uses the artifact's file name (not the full path) so the toast stays short,
+ * and includes the app name inferred from the workspace/input folder when
+ * available.
+ *
+ * @param artifactPath Absolute path to the produced .msix/.msixbundle.
+ * @param appName Optional friendly app name to prefix the message with.
+ */
+export function buildPackSuccessMessage(artifactPath: string, appName?: string): string {
+	const fileName = path.basename(artifactPath);
+	if (appName && appName.trim().length > 0) {
+		return `${appName.trim()} packaged → ${fileName}`;
+	}
+	return `Package created → ${fileName}`;
+}
+
+/**
+ * Derive a friendly app name from a packaged artifact's file name.
+ *
+ * The CLI names artifacts `<name>_<version>_<arch>.msix`, where the version
+ * segment always begins with a digit. We take everything up to the first
+ * `_<digit>` boundary so an app name that itself contains underscores is
+ * preserved (e.g. `My_Cool_App_1.0.0_x64.msix` → `My_Cool_App`).
+ *
+ * @param artifactPath Absolute path or file name of the produced artifact.
+ * @returns The inferred app name, or `undefined` if it cannot be determined.
+ */
+export function deriveAppNameFromArtifact(artifactPath: string): string | undefined {
+	const base = path
+		.basename(artifactPath)
+		.replace(/\.(msixbundle|msix|appxbundle|appx)$/i, '');
+	const match = base.match(/^(.*?)_\d/);
+	if (match && match[1].length > 0) {
+		return match[1];
+	}
+	return undefined;
+}
+

--- a/src/test/pack-result.test.ts
+++ b/src/test/pack-result.test.ts
@@ -4,24 +4,37 @@ import {
 	parsePackagedArtifactPath,
 	buildPackSuccessMessage,
 	deriveAppNameFromArtifact,
-	PACK_ACTIONS
+	PACK_ACTIONS,
+	getPackNotificationAction,
+	isArtifactWithinRoot,
+	planPackCompletion
 } from '../pack-result';
 
 describe('parsePackagedArtifactPath', () => {
-	it('extracts the path when it wraps onto the line after the marker', () => {
-		// This is the real layout observed from the CLI: Spectre.Console wraps the
-		// path onto the next line after "📦 Package:".
+	it('extracts a following-line path that contains spaces', () => {
 		const output = [
 			'Creating MSIX package...\r',
 			'  📦 Package: \r',
-			'C:\\Users\\me\\proj\\CounterApp_1.0.0.0_x64.msix\r',
+			'C:\\Users\\me\\My Project\\My App_1.0.0.0_x64.msix\r',
 			'✅ MSIX package creation completed.\r',
 			''
 		].join('\n');
 
 		assert.equal(
 			parsePackagedArtifactPath(output),
-			'C:\\Users\\me\\proj\\CounterApp_1.0.0.0_x64.msix'
+			'C:\\Users\\me\\My Project\\My App_1.0.0.0_x64.msix'
+		);
+	});
+
+	it('trims an indented following-line path while preserving internal spaces', () => {
+		const output =
+			'Creating MSIX package...\n' +
+			'  📦 Package: \n' +
+			'   C:\\Users\\me\\My Project\\My App_1.0.0.0_x64.msix   \n';
+
+		assert.equal(
+			parsePackagedArtifactPath(output),
+			'C:\\Users\\me\\My Project\\My App_1.0.0.0_x64.msix'
 		);
 	});
 
@@ -143,5 +156,114 @@ describe('PACK_ACTIONS', () => {
 			sign: 'Sign',
 			install: 'Install'
 		});
+	});
+});
+
+describe('getPackNotificationAction', () => {
+	it('maps notification labels to action kinds', () => {
+		assert.equal(getPackNotificationAction(PACK_ACTIONS.reveal), 'reveal');
+		assert.equal(getPackNotificationAction(PACK_ACTIONS.sign), 'sign');
+		assert.equal(getPackNotificationAction(PACK_ACTIONS.install), 'install');
+	});
+
+	it('maps dismissal and unknown choices to none', () => {
+		assert.equal(getPackNotificationAction(undefined), 'none');
+		assert.equal(getPackNotificationAction('Dismiss'), 'none');
+	});
+});
+
+describe('isArtifactWithinRoot', () => {
+	it('accepts an artifact under the root', () => {
+		assert.equal(
+			isArtifactWithinRoot('C:\\workspace\\out\\App_1.0.0.0_x64.msix', 'C:\\workspace'),
+			true
+		);
+	});
+
+	it('rejects a sibling path escape', () => {
+		assert.equal(
+			isArtifactWithinRoot('C:\\workspace-other\\App_1.0.0.0_x64.msix', 'C:\\workspace'),
+			false
+		);
+	});
+
+	it('rejects a different drive', () => {
+		assert.equal(
+			isArtifactWithinRoot('D:\\workspace\\out\\App_1.0.0.0_x64.msix', 'C:\\workspace'),
+			false
+		);
+	});
+
+	it('rejects the exact root path', () => {
+		assert.equal(isArtifactWithinRoot('C:\\workspace', 'C:\\workspace'), false);
+	});
+
+	it('compares paths case-insensitively', () => {
+		assert.equal(
+			isArtifactWithinRoot('c:\\workspace\\out\\App_1.0.0.0_x64.msix', 'C:\\WORKSPACE'),
+			true
+		);
+	});
+
+	it('can be composed to accept a selected input folder outside the workspace', () => {
+		const artifactPath = 'C:\\selected-input\\out\\App_1.0.0.0_x64.msix';
+
+		assert.equal(
+			isArtifactWithinRoot(artifactPath, 'C:\\workspace') ||
+				isArtifactWithinRoot(artifactPath, 'C:\\selected-input'),
+			true
+		);
+		assert.equal(
+			isArtifactWithinRoot('C:\\unrelated\\App_1.0.0.0_x64.msix', 'C:\\workspace') ||
+				isArtifactWithinRoot('C:\\unrelated\\App_1.0.0.0_x64.msix', 'C:\\selected-input'),
+			false
+		);
+	});
+});
+
+describe('planPackCompletion', () => {
+	it('plans a silent cancellation', () => {
+		assert.deepEqual(
+			planPackCompletion({ code: null, output: '', cancelled: true }),
+			{ kind: 'cancelled' }
+		);
+	});
+
+	it('plans an error for non-zero exit code', () => {
+		assert.deepEqual(
+			planPackCompletion({
+				code: 1,
+				output: '  📦 Package: C:\\out\\CounterApp_1.0.0.0_x64.msix\n'
+			}),
+			{
+				kind: 'error',
+				message: 'Packaging failed. See the WinApp output channel for details.'
+			}
+		);
+	});
+
+	it('plans an error for unparseable successful output', () => {
+		assert.deepEqual(
+			planPackCompletion({ code: 0, output: '✅ MSIX package creation completed.\n' }),
+			{
+				kind: 'error',
+				message: 'Packaging failed. See the WinApp output channel for details.'
+			}
+		);
+	});
+
+	it('plans success with the artifact path, app name, and message', () => {
+		assert.deepEqual(
+			planPackCompletion({
+				code: 0,
+				output: '  📦 Package: C:\\out\\CounterApp_1.0.0.0_x64.msix\n'
+			}),
+			{
+				kind: 'success',
+				artifactPath: 'C:\\out\\CounterApp_1.0.0.0_x64.msix',
+				appName: 'CounterApp',
+				message: 'CounterApp packaged → CounterApp_1.0.0.0_x64.msix'
+			}
+		);
 	});
 });

--- a/src/test/pack-result.test.ts
+++ b/src/test/pack-result.test.ts
@@ -1,0 +1,147 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	parsePackagedArtifactPath,
+	buildPackSuccessMessage,
+	deriveAppNameFromArtifact,
+	PACK_ACTIONS
+} from '../pack-result';
+
+describe('parsePackagedArtifactPath', () => {
+	it('extracts the path when it wraps onto the line after the marker', () => {
+		// This is the real layout observed from the CLI: Spectre.Console wraps the
+		// path onto the next line after "📦 Package:".
+		const output = [
+			'Creating MSIX package...\r',
+			'  📦 Package: \r',
+			'C:\\Users\\me\\proj\\CounterApp_1.0.0.0_x64.msix\r',
+			'✅ MSIX package creation completed.\r',
+			''
+		].join('\n');
+
+		assert.equal(
+			parsePackagedArtifactPath(output),
+			'C:\\Users\\me\\proj\\CounterApp_1.0.0.0_x64.msix'
+		);
+	});
+
+	it('extracts the path when it is on the same line as the marker', () => {
+		const output =
+			'Creating MSIX package...\n' +
+			'  📦 Package: C:\\out\\MyApp_2.3.4_arm64.msix\n' +
+			'✅ MSIX package creation completed.\n';
+
+		assert.equal(parsePackagedArtifactPath(output), 'C:\\out\\MyApp_2.3.4_arm64.msix');
+	});
+
+	it('recognizes a .msixbundle artifact', () => {
+		const output =
+			'  📦 Package: \nC:\\out\\MyApp_1.0.0_x64_arm64.msixbundle\n';
+
+		assert.equal(
+			parsePackagedArtifactPath(output),
+			'C:\\out\\MyApp_1.0.0_x64_arm64.msixbundle'
+		);
+	});
+
+	it('falls back to the last package-like line when the marker is absent', () => {
+		const output =
+			'some noisy log line\n' +
+			'C:\\out\\First_1.0.0_x64.msix\n' +
+			'another log line\n' +
+			'C:\\out\\Final_2.0.0_x64.msix\n' +
+			'done\n';
+
+		assert.equal(parsePackagedArtifactPath(output), 'C:\\out\\Final_2.0.0_x64.msix');
+	});
+
+	it('is case-insensitive about the extension', () => {
+		const output = '  📦 Package: \nC:\\out\\MyApp_1.0.0_x64.MSIX\n';
+		assert.equal(parsePackagedArtifactPath(output), 'C:\\out\\MyApp_1.0.0_x64.MSIX');
+	});
+
+	it('returns undefined when no artifact path is present', () => {
+		const output = 'Creating MSIX package...\n❌ Failed to create MSIX package\n';
+		assert.equal(parsePackagedArtifactPath(output), undefined);
+	});
+
+	it('returns undefined for empty output', () => {
+		assert.equal(parsePackagedArtifactPath(''), undefined);
+	});
+
+	it('does not treat a non-package line after the marker as the path', () => {
+		// If the line right after the marker is not a package path, we must not
+		// misreport a log line as the artifact.
+		const output =
+			'  📦 Package: \n' +
+			'Run with --verbose for more details.\n' +
+			'❌ Failed\n';
+		assert.equal(parsePackagedArtifactPath(output), undefined);
+	});
+});
+
+describe('buildPackSuccessMessage', () => {
+	it('uses the file name and app name when provided', () => {
+		assert.equal(
+			buildPackSuccessMessage('C:\\out\\CounterApp_1.0.0.0_x64.msix', 'CounterApp'),
+			'CounterApp packaged → CounterApp_1.0.0.0_x64.msix'
+		);
+	});
+
+	it('falls back to a generic message when no app name is given', () => {
+		assert.equal(
+			buildPackSuccessMessage('C:\\out\\CounterApp_1.0.0.0_x64.msix'),
+			'Package created → CounterApp_1.0.0.0_x64.msix'
+		);
+	});
+
+	it('trims a whitespace-only app name and uses the fallback', () => {
+		assert.equal(
+			buildPackSuccessMessage('C:\\out\\App_1.0_x64.msix', '   '),
+			'Package created → App_1.0_x64.msix'
+		);
+	});
+
+	it('shows only the basename, not the full path', () => {
+		const message = buildPackSuccessMessage('C:\\deep\\nested\\out\\App_1.0_x64.msix', 'App');
+		assert.ok(!message.includes('nested'));
+		assert.ok(message.endsWith('App_1.0_x64.msix'));
+	});
+});
+
+describe('deriveAppNameFromArtifact', () => {
+	it('extracts the name before the version segment', () => {
+		assert.equal(
+			deriveAppNameFromArtifact('C:\\out\\CounterApp_1.0.0.0_x64.msix'),
+			'CounterApp'
+		);
+	});
+
+	it('preserves underscores within the app name', () => {
+		assert.equal(
+			deriveAppNameFromArtifact('C:\\out\\My_Cool_App_1.0.0_x64.msix'),
+			'My_Cool_App'
+		);
+	});
+
+	it('works for bundles', () => {
+		assert.equal(
+			deriveAppNameFromArtifact('App_1.0.0_x64_arm64.msixbundle'),
+			'App'
+		);
+	});
+
+	it('returns undefined when there is no version segment', () => {
+		assert.equal(deriveAppNameFromArtifact('C:\\out\\NoVersion.msix'), undefined);
+	});
+});
+
+describe('PACK_ACTIONS', () => {
+	it('exposes the three action labels', () => {
+		assert.deepEqual(PACK_ACTIONS, {
+			reveal: 'Reveal in Explorer',
+			sign: 'Sign',
+			install: 'Install'
+		});
+	});
+});

--- a/src/test/pack-result.test.ts
+++ b/src/test/pack-result.test.ts
@@ -57,17 +57,6 @@ describe('parsePackagedArtifactPath', () => {
 		);
 	});
 
-	it('falls back to the last package-like line when the marker is absent', () => {
-		const output =
-			'some noisy log line\n' +
-			'C:\\out\\First_1.0.0_x64.msix\n' +
-			'another log line\n' +
-			'C:\\out\\Final_2.0.0_x64.msix\n' +
-			'done\n';
-
-		assert.equal(parsePackagedArtifactPath(output), 'C:\\out\\Final_2.0.0_x64.msix');
-	});
-
 	it('is case-insensitive about the extension', () => {
 		const output = '  📦 Package: \nC:\\out\\MyApp_1.0.0_x64.MSIX\n';
 		assert.equal(parsePackagedArtifactPath(output), 'C:\\out\\MyApp_1.0.0_x64.MSIX');

--- a/src/test/pack-result.test.ts
+++ b/src/test/pack-result.test.ts
@@ -91,6 +91,36 @@ describe('parsePackagedArtifactPath', () => {
 			'❌ Failed\n';
 		assert.equal(parsePackagedArtifactPath(output), undefined);
 	});
+
+	it('reconstructs a path wrapped across multiple lines after the marker', () => {
+		const output = [
+			'⚠ Found `Appx` directory in input folder. It will be excluded from the package.',
+			'  📦 Package:',
+			'c:\\Users\\chiaramooney\\winappCli\\samples\\winui-app\\winui-app-sample_1.0.0.0_arm64',
+			'.msix',
+			'✅ MSIX package creation completed.'
+		].join('\n');
+
+		assert.equal(
+			parsePackagedArtifactPath(output),
+			'c:\\Users\\chiaramooney\\winappCli\\samples\\winui-app\\winui-app-sample_1.0.0.0_arm64.msix'
+		);
+	});
+
+	it('reconstructs a path wrapped across three lines after the marker', () => {
+		const output = [
+			'  📦 Package:',
+			'C:\\very\\long\\path\\to\\some\\deep\\folder\\winui-app-sample_1.0.0.0',
+			'_arm64',
+			'.msix',
+			'✅ Done.'
+		].join('\n');
+
+		assert.equal(
+			parsePackagedArtifactPath(output),
+			'C:\\very\\long\\path\\to\\some\\deep\\folder\\winui-app-sample_1.0.0.0_arm64.msix'
+		);
+	});
 });
 
 describe('buildPackSuccessMessage', () => {


### PR DESCRIPTION
## Description

Adds a **completion notification** to the `winapp.pack` command so the extension tells you when packaging finished and where the MSIX landed, instead of leaving you to hunt through terminal output for the path.

Previously `winapp.pack` fired `winapp pack` into a terminal fire-and-forget and returned immediately, discarding the CLI's `📦 Package: …\<app>_<version>_<arch>.msix` line — no success/failure signal, no pointer to the artifact. Now the command captures the pack output, parses the produced artifact path, and surfaces it in an actionable toast:

> ✅ `<AppName>` packaged → `<AppName>_1.0.0.0_x64.msix`
> **[Reveal in Explorer]  [Sign]  [Install]**

Button behavior:
- **Reveal in Explorer** — `revealFileInOS` on the `.msix` (opens Explorer with the file selected).
- **Sign** — feeds the just-built `.msix` into the existing sign flow, pre-filling the file path.
- **Install** — sideloads the package via `Add-AppxPackage` in a terminal.

This is the extension-UX follow-up carved out of #35 (the CLI already names/locates packages correctly).

## Usage Example

Run **WinApp: Create MSIX Package** (`winapp.pack`) from the Command Palette, pick the build-output folder, and answer the cert / self-contained prompts. When packaging completes, the notification appears with the three action buttons.

## Related Issue

Closes #62. Refs #35.

## Type of Change

- ✨ New feature

## Checklist

- [x] New tests added for new functionality (if applicable)
- [x] Ran `.\scripts\build-vsce.ps1` locally
- [x] Tested locally on Windows (if applicable)
- [x] [README.md](../README.md) updated (if applicable)
- [x] `package.json` contribution points / command/debugger/custom-editor docs updated (if extension surface changed)
- [x] Screenshots or GIFs added for UI changes (if applicable)

## Screenshots / Demo

Live-tested by driving the real extension command inside a VS Code instance (via the winapp-ux-agent driver harness), which produced a real 61 MB MSIX.

**Completion notification with Reveal in Explorer / Sign / Install actions:**

<!-- DRAG pack-notification-live.png HERE -->

**Reveal in Explorer action opening the built package:**

<!-- DRAG pack-notif-reveal-explorer.png HERE -->

## Additional Notes

Implementation follows repo conventions: pure, VS Code-free logic (`parsePackagedArtifactPath`, `buildPackSuccessMessage`, `deriveAppNameFromArtifact`, `planPackCompletion`, `getPackNotificationAction`, `isArtifactWithinRoot`) lives in `src/pack-result.ts` and is unit-tested with `node:test` + tsx; `handlePackCompletion` is thin, un-mocked vscode wiring over those helpers. Hardening from an iterative PR review is included: the packaging progress is cancellable (kills the full Windows process tree on cancel), picker cancellations are graceful no-ops, the parser preserves paths with spaces, and Reveal/Sign/Install are only enabled when the parsed artifact exists and resides under the workspace or the selected input folder. Full unit suite: 622 passing.


