### PR TITLE
feat: surface target architecture and warn on mismatch during pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All commands are accessible from the Command Palette (`Ctrl+Shift+P`). Type **Wi
 | **WinApp: Run Application** | Run your app as a loose-layout packaged application with full package identity — great for testing APIs that require identity. |
 | **WinApp: Create Debug Identity** | Add sparse package identity to an existing executable so you can launch and debug it directly from VS Code with identity. |
 | **WinApp: Unregister Package** | Unregister a sideloaded development package (e.g., one registered via Run or Create Debug Identity). |
-| **WinApp: Create MSIX Package** | Package your application into an MSIX, with options to generate a certificate and bundle the runtime self-contained. On completion, a notification names the built package and offers **Reveal in Explorer**, **Sign**, and **Install** actions. |
+| **WinApp: Create MSIX Package** | Package your application into an MSIX, with options to generate a certificate and bundle the runtime self-contained. If self-contained packaging appears to target a different architecture than your machine, WinApp shows a warning before continuing. On completion, a notification names the built package and offers **Reveal in Explorer**, **Sign**, and **Install** actions. |
 | **WinApp: Generate Manifest** | Generate an `AppxManifest.xml` from a template (packaged or sparse). |
 | **WinApp: Add Manifest Execution Alias** | Add an execution alias to the manifest so the packaged app can be launched from the command line. |
 | **WinApp: Update Manifest Assets** | Auto-generate all required app icon assets from a single source image (PNG, JPG, GIF, or BMP). |
@@ -214,7 +214,7 @@ Use **WinApp: Generate Manifest** to create an `Package.appxmanifest` from a tem
 
 ### Package and sign
 
-Use **WinApp: Create MSIX Package** to package your application. When packaging finishes, a completion notification names the built `.msix` and offers three actions: **Reveal in Explorer** (open the package in File Explorer), **Sign** (sign the just-built package, pre-filling its path), and **Install** (sideload it via `Add-AppxPackage`). Pair it with **WinApp: Generate Certificate** and **WinApp: Sign Package** to produce a signed, ready-to-distribute MSIX. Use **WinApp: Certificate Info** to verify a certificate's details (subject, thumbprint, expiry) before signing.
+Use **WinApp: Create MSIX Package** to package your application. If you choose **self-contained** packaging and the selected build output path appears to target a different architecture than your machine, WinApp shows a warning before continuing so you can avoid bundling the wrong Windows App SDK runtime. When packaging finishes, a completion notification names the built `.msix` and offers three actions: **Reveal in Explorer** (open the package in File Explorer), **Sign** (sign the just-built package, pre-filling its path), and **Install** (sideload it via `Add-AppxPackage`). Pair it with **WinApp: Generate Certificate** and **WinApp: Sign Package** to produce a signed, ready-to-distribute MSIX. Use **WinApp: Certificate Info** to verify a certificate's details (subject, thumbprint, expiry) before signing.
 
 ### Access Windows SDK tools
 

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "clean": "node -e \"require('fs').rmSync('bin', {recursive: true, force: true}); require('fs').rmSync('out', {recursive: true, force: true}); require('fs').rmSync('dist', {recursive: true, force: true});\"",
     "download-cli": "pwsh -NoProfile -Command \"& ./scripts/download-cli.ps1\"",
     "download-cli:latest": "pwsh -NoProfile -Command \"& ./scripts/download-cli.ps1 -Tag latest\"",
-    "test:unit": "tsc -p ./ && node -e \"require('fs').cpSync('src/test/fixtures','out/test/fixtures',{recursive:true})\" && mocha out/test/project-detection.test.js && npx tsx --test src/test/debugger-resolver.test.ts src/test/extension-field-validator.test.ts src/test/extension-templates.test.ts src/test/manifest-edge-cases.test.ts src/test/manifest-parser.test.ts src/test/manifest-validator.test.ts src/test/project-resolver.test.ts src/test/redos-prevention.test.ts src/test/xml-utils.test.ts src/test/shell-escape.test.ts src/test/noop-debug-adapter.test.ts src/test/pack-result.test.ts"
+    "test:unit": "tsc -p ./ && node -e \"require('fs').cpSync('src/test/fixtures','out/test/fixtures',{recursive:true})\" && mocha out/test/project-detection.test.js && npx tsx --test src/test/arch-detection.test.ts src/test/debugger-resolver.test.ts src/test/extension-field-validator.test.ts src/test/extension-templates.test.ts src/test/manifest-edge-cases.test.ts src/test/manifest-parser.test.ts src/test/manifest-validator.test.ts src/test/project-resolver.test.ts src/test/redos-prevention.test.ts src/test/xml-utils.test.ts src/test/shell-escape.test.ts src/test/noop-debug-adapter.test.ts src/test/pack-result.test.ts"
   },
   "dependencies": {
     "@xmldom/xmldom": "^0.9.9",

--- a/src/arch-detection.ts
+++ b/src/arch-detection.ts
@@ -17,6 +17,9 @@ export type PackageArch = 'x64' | 'arm64' | 'x86';
  * segment that might appear elsewhere.
  */
 const RID_PATTERNS: { pattern: RegExp; arch: PackageArch }[] = [
+	{ pattern: /^win\d[\d.]*-arm64$/i, arch: 'arm64' },
+	{ pattern: /^win\d[\d.]*-x64$/i, arch: 'x64' },
+	{ pattern: /^win\d[\d.]*-x86$/i, arch: 'x86' },
 	{ pattern: /^win-arm64$/i, arch: 'arm64' },
 	{ pattern: /^win-x64$/i, arch: 'x64' },
 	{ pattern: /^win-x86$/i, arch: 'x86' },

--- a/src/arch-detection.ts
+++ b/src/arch-detection.ts
@@ -1,0 +1,141 @@
+import * as path from 'path';
+import * as os from 'os';
+
+/**
+ * Pure helpers for detecting the target architecture from a build-output folder
+ * path and warning about architecture mismatches during packaging. These are
+ * free of the VS Code API so they can be unit-tested directly (see
+ * `src/test/arch-detection.test.ts`); the VS Code-facing wiring lives in
+ * `extension.ts`.
+ */
+
+/** Architectures the WinApp CLI can package for. */
+export type PackageArch = 'x64' | 'arm64' | 'x86';
+
+const KNOWN_ARCHS: PackageArch[] = ['arm64', 'x64', 'x86'];
+
+/**
+ * Patterns that indicate an architecture in a path segment.
+ * Ordered most-specific first so `win-arm64` matches before a bare `arm64`
+ * segment that might appear elsewhere.
+ */
+const RID_PATTERNS: { pattern: RegExp; arch: PackageArch }[] = [
+	{ pattern: /^win-arm64$/i, arch: 'arm64' },
+	{ pattern: /^win-x64$/i, arch: 'x64' },
+	{ pattern: /^win-x86$/i, arch: 'x86' },
+	{ pattern: /^arm64$/i, arch: 'arm64' },
+	{ pattern: /^x64$/i, arch: 'x64' },
+	{ pattern: /^x86$/i, arch: 'x86' },
+];
+
+/**
+ * Detect the target architecture from a build-output folder path by looking
+ * for RID-style segments (e.g. `win-x64`, `arm64`, `x64`).
+ *
+ * Scans path segments from right to left (the deepest segments are the most
+ * specific) and returns the first match. Returns `undefined` when no
+ * architecture can be inferred.
+ *
+ * @param folderPath Absolute or relative path to the build-output folder.
+ * @returns The detected architecture, or `undefined`.
+ */
+export function detectArchFromPath(folderPath: string): PackageArch | undefined {
+	// Normalise the path and split into segments. Use both separators so this
+	// works on any OS and with paths that mix forward/back slashes.
+	const segments = folderPath.replace(/\\/g, '/').split('/').filter(Boolean);
+
+	// Walk right-to-left — the most specific (deepest) segment wins.
+	for (let i = segments.length - 1; i >= 0; i--) {
+		for (const { pattern, arch } of RID_PATTERNS) {
+			if (pattern.test(segments[i])) {
+				return arch;
+			}
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Map `os.arch()` values to the corresponding {@link PackageArch}.
+ * Returns `undefined` for architectures the WinApp CLI does not support.
+ */
+export function getMachineArch(): PackageArch | undefined {
+	const nodeArch = os.arch();
+	switch (nodeArch) {
+		case 'x64':
+			return 'x64';
+		case 'arm64':
+			return 'arm64';
+		case 'ia32':
+			return 'x86';
+		default:
+			return undefined;
+	}
+}
+
+export type ArchMismatchResult =
+	| { mismatch: false }
+	| { mismatch: true; buildArch: PackageArch; machineArch: PackageArch };
+
+/**
+ * Check whether a self-contained package would bundle a runtime whose
+ * architecture differs from the build output in the selected input folder.
+ *
+ * When `--self-contained` is used the CLI bundles the Windows App SDK runtime
+ * that matches the **machine's** architecture, not the build output's
+ * architecture. Packaging x64 binaries on an ARM64 host with self-contained
+ * silently produces an arm64 runtime alongside x64 app binaries — a real
+ * footgun.
+ *
+ * @param buildArch Architecture detected from the build-output folder.
+ * @param machineArch Architecture of the current machine (from `os.arch()`).
+ * @returns A result indicating whether a mismatch exists, and if so, the details.
+ */
+export function checkSelfContainedArchMismatch(
+	buildArch: PackageArch | undefined,
+	machineArch: PackageArch | undefined
+): ArchMismatchResult {
+	if (!buildArch || !machineArch) {
+		return { mismatch: false };
+	}
+	if (buildArch === machineArch) {
+		return { mismatch: false };
+	}
+	return { mismatch: true, buildArch, machineArch };
+}
+
+/**
+ * Build a human-readable warning message for an architecture mismatch.
+ */
+export function buildArchMismatchWarning(buildArch: PackageArch, machineArch: PackageArch): string {
+	return (
+		`Architecture mismatch: the selected build output appears to target ${buildArch}, ` +
+		`but this machine is ${machineArch}. A self-contained package will bundle the ` +
+		`${machineArch} Windows App SDK runtime alongside ${buildArch} app binaries, ` +
+		`which may not work correctly.`
+	);
+}
+
+/**
+ * Return an ordered list of architecture choices for the QuickPick, with the
+ * detected architecture (if any) presented first and marked as default.
+ */
+export function buildArchChoices(detectedArch: PackageArch | undefined): string[] {
+	if (!detectedArch) {
+		return KNOWN_ARCHS.map((a) => a);
+	}
+	const rest = KNOWN_ARCHS.filter((a) => a !== detectedArch);
+	return [`${detectedArch} (detected)`, ...rest];
+}
+
+/**
+ * Parse a QuickPick selection back to a {@link PackageArch}.
+ * Handles both plain labels (`x64`) and annotated labels (`x64 (detected)`).
+ */
+export function parseArchChoice(choice: string): PackageArch | undefined {
+	const stripped = choice.replace(/\s*\(detected\)\s*$/i, '').trim().toLowerCase();
+	if (KNOWN_ARCHS.includes(stripped as PackageArch)) {
+		return stripped as PackageArch;
+	}
+	return undefined;
+}

--- a/src/arch-detection.ts
+++ b/src/arch-detection.ts
@@ -70,6 +70,7 @@ export function getMachineArch(machineString?: string): PackageArch | undefined 
 			return 'arm64';
 		case 'x86':
 		case 'ia32':
+		case 'i386':
 		case 'i686':
 			return 'x86';
 		case 'unknown':

--- a/src/arch-detection.ts
+++ b/src/arch-detection.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import * as os from 'os';
 
 /**
@@ -11,8 +10,6 @@ import * as os from 'os';
 
 /** Architectures the WinApp CLI can package for. */
 export type PackageArch = 'x64' | 'arm64' | 'x86';
-
-const KNOWN_ARCHS: PackageArch[] = ['arm64', 'x64', 'x86'];
 
 /**
  * Patterns that indicate an architecture in a path segment.
@@ -56,18 +53,24 @@ export function detectArchFromPath(folderPath: string): PackageArch | undefined 
 }
 
 /**
- * Map `os.arch()` values to the corresponding {@link PackageArch}.
+ * Map `os.machine()` values to the corresponding {@link PackageArch}.
  * Returns `undefined` for architectures the WinApp CLI does not support.
  */
-export function getMachineArch(): PackageArch | undefined {
-	const nodeArch = os.arch();
-	switch (nodeArch) {
+export function getMachineArch(machineString?: string): PackageArch | undefined {
+	const arch = machineString ?? os.machine();
+	switch (arch) {
 		case 'x64':
+		case 'x86_64':
 			return 'x64';
 		case 'arm64':
+		case 'aarch64':
 			return 'arm64';
+		case 'x86':
 		case 'ia32':
+		case 'i686':
 			return 'x86';
+		case 'unknown':
+			return machineString === undefined ? getMachineArch(os.arch()) : undefined;
 		default:
 			return undefined;
 	}
@@ -88,7 +91,7 @@ export type ArchMismatchResult =
  * footgun.
  *
  * @param buildArch Architecture detected from the build-output folder.
- * @param machineArch Architecture of the current machine (from `os.arch()`).
+ * @param machineArch Architecture of the current machine (from `os.machine()`).
  * @returns A result indicating whether a mismatch exists, and if so, the details.
  */
 export function checkSelfContainedArchMismatch(
@@ -114,28 +117,4 @@ export function buildArchMismatchWarning(buildArch: PackageArch, machineArch: Pa
 		`${machineArch} Windows App SDK runtime alongside ${buildArch} app binaries, ` +
 		`which may not work correctly.`
 	);
-}
-
-/**
- * Return an ordered list of architecture choices for the QuickPick, with the
- * detected architecture (if any) presented first and marked as default.
- */
-export function buildArchChoices(detectedArch: PackageArch | undefined): string[] {
-	if (!detectedArch) {
-		return KNOWN_ARCHS.map((a) => a);
-	}
-	const rest = KNOWN_ARCHS.filter((a) => a !== detectedArch);
-	return [`${detectedArch} (detected)`, ...rest];
-}
-
-/**
- * Parse a QuickPick selection back to a {@link PackageArch}.
- * Handles both plain labels (`x64`) and annotated labels (`x64 (detected)`).
- */
-export function parseArchChoice(choice: string): PackageArch | undefined {
-	const stripped = choice.replace(/\s*\(detected\)\s*$/i, '').trim().toLowerCase();
-	if (KNOWN_ARCHS.includes(stripped as PackageArch)) {
-		return stripped as PackageArch;
-	}
-	return undefined;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,9 +24,7 @@ import {
 	detectArchFromPath,
 	getMachineArch,
 	checkSelfContainedArchMismatch,
-	buildArchMismatchWarning,
-	buildArchChoices,
-	parseArchChoice
+	buildArchMismatchWarning
 } from './arch-detection';
 import {
 	DEBUGGER_CHOICE_LABELS,
@@ -978,19 +976,6 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
-			// --- Architecture detection ---
-			const detectedArch = detectArchFromPath(inputFolder);
-			const archChoices = buildArchChoices(detectedArch);
-			const archPick = await vscode.window.showQuickPick(archChoices, {
-				placeHolder: detectedArch
-					? `Target architecture: ${detectedArch} (detected from build output path)`
-					: 'Select target architecture'
-			});
-			if (!archPick) {
-				return;
-			}
-			const selectedArch = parseArchChoice(archPick);
-
 			const generateCert = await vscode.window.showQuickPick(
 				['Yes', 'No'],
 				{ placeHolder: 'Generate and install a development certificate?' }
@@ -1002,9 +987,10 @@ export function activate(context: vscode.ExtensionContext) {
 			);
 
 			// --- Architecture mismatch warning for self-contained packages ---
-			if (selfContained === 'Yes' && selectedArch) {
+			if (selfContained === 'Yes') {
+				const detectedArch = detectArchFromPath(inputFolder);
 				const machineArch = getMachineArch();
-				const mismatchResult = checkSelfContainedArchMismatch(selectedArch, machineArch);
+				const mismatchResult = checkSelfContainedArchMismatch(detectedArch, machineArch);
 				if (mismatchResult.mismatch) {
 					const warning = buildArchMismatchWarning(mismatchResult.buildArch, mismatchResult.machineArch);
 					const proceed = await vscode.window.showWarningMessage(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,14 @@ import {
 	planPackCompletion
 } from './pack-result';
 import {
+	detectArchFromPath,
+	getMachineArch,
+	checkSelfContainedArchMismatch,
+	buildArchMismatchWarning,
+	buildArchChoices,
+	parseArchChoice
+} from './arch-detection';
+import {
 	DEBUGGER_CHOICE_LABELS,
 	chooseInstalledDebuggerType,
 	getDebuggerExtensionRequirement,
@@ -970,6 +978,19 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
+			// --- Architecture detection ---
+			const detectedArch = detectArchFromPath(inputFolder);
+			const archChoices = buildArchChoices(detectedArch);
+			const archPick = await vscode.window.showQuickPick(archChoices, {
+				placeHolder: detectedArch
+					? `Target architecture: ${detectedArch} (detected from build output path)`
+					: 'Select target architecture'
+			});
+			if (!archPick) {
+				return;
+			}
+			const selectedArch = parseArchChoice(archPick);
+
 			const generateCert = await vscode.window.showQuickPick(
 				['Yes', 'No'],
 				{ placeHolder: 'Generate and install a development certificate?' }
@@ -979,6 +1000,23 @@ export function activate(context: vscode.ExtensionContext) {
 				['Yes', 'No'],
 				{ placeHolder: 'Bundle Windows App SDK runtime (self-contained)?' }
 			);
+
+			// --- Architecture mismatch warning for self-contained packages ---
+			if (selfContained === 'Yes' && selectedArch) {
+				const machineArch = getMachineArch();
+				const mismatchResult = checkSelfContainedArchMismatch(selectedArch, machineArch);
+				if (mismatchResult.mismatch) {
+					const warning = buildArchMismatchWarning(mismatchResult.buildArch, mismatchResult.machineArch);
+					const proceed = await vscode.window.showWarningMessage(
+						warning,
+						{ modal: true },
+						'Continue anyway'
+					);
+					if (proceed !== 'Continue anyway') {
+						return;
+					}
+				}
+			}
 
 			// Build the argument array for spawn (shell: false) so paths and flags
 			// are passed literally — no PowerShell parsing/escaping required.

--- a/src/test/arch-detection.test.ts
+++ b/src/test/arch-detection.test.ts
@@ -129,6 +129,10 @@ describe('getMachineArch', () => {
 		assert.equal(getMachineArch('i686'), 'x86');
 	});
 
+	it('maps i386 to x86', () => {
+		assert.equal(getMachineArch('i386'), 'x86');
+	});
+
 	it('returns undefined for unknown architectures', () => {
 		assert.equal(getMachineArch('unknown'), undefined);
 	});

--- a/src/test/arch-detection.test.ts
+++ b/src/test/arch-detection.test.ts
@@ -4,8 +4,7 @@ import {
 	detectArchFromPath,
 	checkSelfContainedArchMismatch,
 	buildArchMismatchWarning,
-	buildArchChoices,
-	parseArchChoice
+	getMachineArch
 } from '../arch-detection';
 
 describe('detectArchFromPath', () => {
@@ -101,40 +100,24 @@ describe('buildArchMismatchWarning', () => {
 	});
 });
 
-describe('buildArchChoices', () => {
-	it('puts detected arch first with annotation', () => {
-		const choices = buildArchChoices('arm64');
-		assert.equal(choices[0], 'arm64 (detected)');
-		assert.ok(choices.includes('x64'));
-		assert.ok(choices.includes('x86'));
-		assert.equal(choices.length, 3);
+describe('getMachineArch', () => {
+	it('maps x86_64 to x64', () => {
+		assert.equal(getMachineArch('x86_64'), 'x64');
 	});
 
-	it('returns all architectures unannotated when none is detected', () => {
-		const choices = buildArchChoices(undefined);
-		assert.deepEqual(choices, ['arm64', 'x64', 'x86']);
+	it('maps aarch64 to arm64', () => {
+		assert.equal(getMachineArch('aarch64'), 'arm64');
 	});
 
-	it('does not duplicate the detected architecture', () => {
-		const choices = buildArchChoices('x64');
-		const x64Count = choices.filter((c) => c.startsWith('x64')).length;
-		assert.equal(x64Count, 1);
-	});
-});
-
-describe('parseArchChoice', () => {
-	it('parses a plain architecture label', () => {
-		assert.equal(parseArchChoice('x64'), 'x64');
-		assert.equal(parseArchChoice('arm64'), 'arm64');
-		assert.equal(parseArchChoice('x86'), 'x86');
+	it('maps i686 to x86', () => {
+		assert.equal(getMachineArch('i686'), 'x86');
 	});
 
-	it('strips the (detected) annotation', () => {
-		assert.equal(parseArchChoice('arm64 (detected)'), 'arm64');
-		assert.equal(parseArchChoice('x64 (detected)'), 'x64');
+	it('returns undefined for unknown architectures', () => {
+		assert.equal(getMachineArch('unknown'), undefined);
 	});
 
-	it('returns undefined for unrecognised values', () => {
-		assert.equal(parseArchChoice('unknown'), undefined);
+	it('returns a defined value on the current machine', () => {
+		assert.notEqual(getMachineArch(), undefined);
 	});
 });

--- a/src/test/arch-detection.test.ts
+++ b/src/test/arch-detection.test.ts
@@ -20,6 +20,22 @@ describe('detectArchFromPath', () => {
 		assert.equal(detectArchFromPath('C:\\proj\\bin\\Debug\\net8.0-windows\\win-x86'), 'x86');
 	});
 
+	it('detects x64 from a versioned win10-x64 RID segment', () => {
+		assert.equal(detectArchFromPath('C:\\proj\\bin\\Debug\\net8.0-windows\\win10-x64'), 'x64');
+	});
+
+	it('detects arm64 from a versioned win10-arm64 RID segment', () => {
+		assert.equal(detectArchFromPath('C:\\proj\\bin\\Release\\net8.0-windows\\win10-arm64'), 'arm64');
+	});
+
+	it('detects x86 from a versioned win11-x86 RID segment', () => {
+		assert.equal(detectArchFromPath('C:\\proj\\bin\\Debug\\net8.0-windows\\win11-x86'), 'x86');
+	});
+
+	it('detects x64 from a dotted versioned RID segment', () => {
+		assert.equal(detectArchFromPath('C:\\proj\\bin\\Debug\\net8.0-windows\\win10.0.22621-x64'), 'x64');
+	});
+
 	it('detects x64 from a bare x64 folder name', () => {
 		assert.equal(detectArchFromPath('C:\\proj\\publish\\x64'), 'x64');
 	});

--- a/src/test/arch-detection.test.ts
+++ b/src/test/arch-detection.test.ts
@@ -1,0 +1,140 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	detectArchFromPath,
+	checkSelfContainedArchMismatch,
+	buildArchMismatchWarning,
+	buildArchChoices,
+	parseArchChoice
+} from '../arch-detection';
+
+describe('detectArchFromPath', () => {
+	it('detects x64 from a win-x64 RID segment', () => {
+		assert.equal(detectArchFromPath('C:\\proj\\bin\\Debug\\net8.0-windows\\win-x64'), 'x64');
+	});
+
+	it('detects arm64 from a win-arm64 RID segment', () => {
+		assert.equal(detectArchFromPath('C:\\proj\\bin\\Release\\net8.0-windows\\win-arm64'), 'arm64');
+	});
+
+	it('detects x86 from a win-x86 RID segment', () => {
+		assert.equal(detectArchFromPath('C:\\proj\\bin\\Debug\\net8.0-windows\\win-x86'), 'x86');
+	});
+
+	it('detects x64 from a bare x64 folder name', () => {
+		assert.equal(detectArchFromPath('C:\\proj\\publish\\x64'), 'x64');
+	});
+
+	it('detects arm64 from a bare arm64 folder name', () => {
+		assert.equal(detectArchFromPath('C:\\proj\\publish\\arm64'), 'arm64');
+	});
+
+	it('detects architecture from a forward-slash path', () => {
+		assert.equal(detectArchFromPath('C:/proj/bin/Debug/net8.0-windows/win-arm64'), 'arm64');
+	});
+
+	it('prefers the deepest (rightmost) matching segment', () => {
+		// In a path like publish/x64/win-arm64, the deepest match (win-arm64) wins
+		assert.equal(detectArchFromPath('C:\\proj\\publish\\x64\\win-arm64'), 'arm64');
+	});
+
+	it('is case-insensitive', () => {
+		assert.equal(detectArchFromPath('C:\\proj\\bin\\Win-X64'), 'x64');
+		assert.equal(detectArchFromPath('C:\\proj\\bin\\ARM64'), 'arm64');
+	});
+
+	it('returns undefined when no architecture segment exists', () => {
+		assert.equal(detectArchFromPath('C:\\proj\\bin\\Debug\\net8.0-windows'), undefined);
+	});
+
+	it('returns undefined for an empty path', () => {
+		assert.equal(detectArchFromPath(''), undefined);
+	});
+
+	it('does not false-positive on partial matches', () => {
+		// "x64-tools" should not match as x64
+		assert.equal(detectArchFromPath('C:\\proj\\x64-tools\\output'), undefined);
+	});
+});
+
+describe('checkSelfContainedArchMismatch', () => {
+	it('returns no mismatch when architectures match', () => {
+		const result = checkSelfContainedArchMismatch('x64', 'x64');
+		assert.equal(result.mismatch, false);
+	});
+
+	it('returns mismatch when build is x64 but machine is arm64', () => {
+		const result = checkSelfContainedArchMismatch('x64', 'arm64');
+		assert.equal(result.mismatch, true);
+		if (result.mismatch) {
+			assert.equal(result.buildArch, 'x64');
+			assert.equal(result.machineArch, 'arm64');
+		}
+	});
+
+	it('returns mismatch when build is arm64 but machine is x64', () => {
+		const result = checkSelfContainedArchMismatch('arm64', 'x64');
+		assert.equal(result.mismatch, true);
+		if (result.mismatch) {
+			assert.equal(result.buildArch, 'arm64');
+			assert.equal(result.machineArch, 'x64');
+		}
+	});
+
+	it('returns no mismatch when buildArch is undefined', () => {
+		const result = checkSelfContainedArchMismatch(undefined, 'x64');
+		assert.equal(result.mismatch, false);
+	});
+
+	it('returns no mismatch when machineArch is undefined', () => {
+		const result = checkSelfContainedArchMismatch('x64', undefined);
+		assert.equal(result.mismatch, false);
+	});
+});
+
+describe('buildArchMismatchWarning', () => {
+	it('includes both architectures in the message', () => {
+		const msg = buildArchMismatchWarning('x64', 'arm64');
+		assert.ok(msg.includes('x64'));
+		assert.ok(msg.includes('arm64'));
+		assert.ok(msg.includes('mismatch'));
+	});
+});
+
+describe('buildArchChoices', () => {
+	it('puts detected arch first with annotation', () => {
+		const choices = buildArchChoices('arm64');
+		assert.equal(choices[0], 'arm64 (detected)');
+		assert.ok(choices.includes('x64'));
+		assert.ok(choices.includes('x86'));
+		assert.equal(choices.length, 3);
+	});
+
+	it('returns all architectures unannotated when none is detected', () => {
+		const choices = buildArchChoices(undefined);
+		assert.deepEqual(choices, ['arm64', 'x64', 'x86']);
+	});
+
+	it('does not duplicate the detected architecture', () => {
+		const choices = buildArchChoices('x64');
+		const x64Count = choices.filter((c) => c.startsWith('x64')).length;
+		assert.equal(x64Count, 1);
+	});
+});
+
+describe('parseArchChoice', () => {
+	it('parses a plain architecture label', () => {
+		assert.equal(parseArchChoice('x64'), 'x64');
+		assert.equal(parseArchChoice('arm64'), 'arm64');
+		assert.equal(parseArchChoice('x86'), 'x86');
+	});
+
+	it('strips the (detected) annotation', () => {
+		assert.equal(parseArchChoice('arm64 (detected)'), 'arm64');
+		assert.equal(parseArchChoice('x64 (detected)'), 'x64');
+	});
+
+	it('returns undefined for unrecognised values', () => {
+		assert.equal(parseArchChoice('unknown'), undefined);
+	});
+});


### PR DESCRIPTION
## Summary

Addresses the third proposal from #36: **Surface the target architecture explicitly (defaulted from the RID) and warn on mismatch between the selected build output's arch and the package arch.**

When the user runs **WinApp: Create MSIX Package** and selects **self-contained** packaging, the extension now:

1. **Silently detects** the target architecture from the build-output folder path by matching RID-style segments (`win-x64`, `win10-arm64`, `arm64`, etc.)
2. **Detects the machine architecture** using `os.machine()` (real hardware arch, not Node process arch)
3. **Shows a modal warning** if there's a mismatch — e.g., packaging x64 binaries on an ARM64 machine with self-contained would silently bundle the wrong Windows App SDK runtime

The warning includes a **"Continue anyway"** button so it's never blocking.

## Changes

| File | What |
|------|------|
| `src/arch-detection.ts` | New pure helper module: `detectArchFromPath()`, `getMachineArch()`, `checkSelfContainedArchMismatch()`, `buildArchMismatchWarning()` |
| `src/extension.ts` | Integrates mismatch check into `winapp.pack` after the self-contained QuickPick |
| `src/test/arch-detection.test.ts` | 27 unit tests covering all exported functions |
| `README.md` | Updated pack command documentation |
| `package.json` | Added new test file to `test:unit` script |

## Design decisions

- **Silent detection, no extra prompt** — The CLI has no `--arch` flag, so a mandatory architecture QuickPick would be disconnected from the actual packaging. Instead, detection is automatic and the warning only fires when needed.
- **`os.machine()` over `os.arch()`** — `os.arch()` returns the Node process architecture (x64 VS Code on ARM64 reports x64). `os.machine()` returns the real hardware architecture.
- **Versioned RID support** — Handles `win10-x64`, `win10.0.22621-arm64`, etc. in addition to standard `win-x64` and bare `x64` segments.
- **Pure helper pattern** — Follows the same testability pattern as `pack-result.ts`: pure functions free of VS Code API, tested directly.

## Testing

- ✅ 27 unit tests (all pass)
- ✅ Live-tested via the winapp-ux-agent driver harness (all 4 prompts answered, pack completed)
- ✅ Lint clean (0 new warnings)
- ✅ Build clean

## Related issues

- Filed #80 for test coverage of `getMachineArch` unknown fallback branch
- Filed #81 for ancestor path segment false positives (low severity, has override)