### PR TITLE
Validate inputFolder in debugger before launching app

### DIFF
--- a/src/debugger-resolver.ts
+++ b/src/debugger-resolver.ts
@@ -1,6 +1,60 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { glob } from 'glob';
+
 export interface DebuggerExtensionRequirement {
 	id: string;
 	name: string;
+}
+
+export type InputFolderValidation = {
+	valid: true;
+} | {
+	valid: false;
+	reason: 'not-found' | 'not-directory' | 'no-exe';
+	message: string;
+};
+
+/**
+ * Validates that an inputFolder path is suitable for a debug launch:
+ * - The path must exist
+ * - It must be a directory
+ * - It must contain at least one .exe file
+ *
+ * Relative paths are resolved against the provided cwd.
+ */
+export async function validateInputFolder(inputFolder: string, cwd: string): Promise<InputFolderValidation> {
+	const resolvedFolder = path.isAbsolute(inputFolder) ? inputFolder : path.resolve(cwd, inputFolder);
+	const folderStat = await fs.promises.stat(resolvedFolder).catch(() => undefined);
+	if (!folderStat) {
+		return {
+			valid: false,
+			reason: 'not-found',
+			message: `The configured "inputFolder" path does not exist: ${inputFolder}. `
+				+ 'Build your project first, or update "inputFolder" in launch.json to point to your build output directory.'
+		};
+	}
+
+	if (!folderStat.isDirectory()) {
+		return {
+			valid: false,
+			reason: 'not-directory',
+			message: `The configured "inputFolder" is not a directory: ${inputFolder}. `
+				+ 'Update "inputFolder" in launch.json to point to the folder containing your built application.'
+		};
+	}
+
+	const exesInFolder = await glob('*.exe', { cwd: resolvedFolder, absolute: true, nocase: true });
+	if (exesInFolder.length === 0) {
+		return {
+			valid: false,
+			reason: 'no-exe',
+			message: `The configured "inputFolder" does not contain any .exe files: ${inputFolder}. `
+				+ 'Build your project first, or update "inputFolder" in launch.json to point to the folder containing your built application.'
+		};
+	}
+
+	return { valid: true };
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -745,6 +745,28 @@ class WinAppDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory 
 			// If not set in launch.json, search for folders containing .exe
 			// files and let the user pick one.
 			let inputFolder: string | undefined = config.inputFolder;
+
+			// Validate a user-specified inputFolder before proceeding.
+			if (inputFolder) {
+				const folderExists = await fs.promises.access(inputFolder).then(() => true, () => false);
+				if (!folderExists) {
+					vscode.window.showErrorMessage(
+						`The configured "inputFolder" path does not exist: ${inputFolder}. ` +
+						'Build your project first, or update "inputFolder" in launch.json to point to your build output directory.'
+					);
+					return new vscode.DebugAdapterInlineImplementation(new NoOpDebugAdapter());
+				}
+
+				const exesInFolder = await glob('*.exe', { cwd: inputFolder, absolute: true, nocase: true });
+				if (exesInFolder.length === 0) {
+					vscode.window.showErrorMessage(
+						`The configured "inputFolder" does not contain any .exe files: ${inputFolder}. ` +
+						'Build your project first, or update "inputFolder" in launch.json to point to the folder containing your built application.'
+					);
+					return new vscode.DebugAdapterInlineImplementation(new NoOpDebugAdapter());
+				}
+			}
+
 			if (!inputFolder) {
 				const exeMatches = await glob('**/*.exe', {
 					cwd: folder.uri.fsPath,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,8 @@ import {
 	DEBUGGER_CHOICE_LABELS,
 	chooseInstalledDebuggerType,
 	getDebuggerExtensionRequirement,
-	getDebuggerTypeFromChoice
+	getDebuggerTypeFromChoice,
+	validateInputFolder
 } from './debugger-resolver';
 import { NoOpDebugAdapter } from './noop-debug-adapter';
 
@@ -727,30 +728,9 @@ class WinAppDebugConfigurationProvider implements vscode.DebugConfigurationProvi
 			if (config.workingDirectory) {
 				cwd = config.workingDirectory;
 			}
-			const resolvedFolder = path.isAbsolute(inputFolder) ? inputFolder : path.resolve(cwd, inputFolder);
-			const folderStat = await fs.promises.stat(resolvedFolder).catch(() => undefined);
-			if (!folderStat) {
-				vscode.window.showErrorMessage(
-					`The configured "inputFolder" path does not exist: ${inputFolder}. ` +
-					'Build your project first, or update "inputFolder" in launch.json to point to your build output directory.'
-				);
-				return undefined;
-			}
-
-			if (!folderStat.isDirectory()) {
-				vscode.window.showErrorMessage(
-					`The configured "inputFolder" is not a directory: ${inputFolder}. ` +
-					'Update "inputFolder" in launch.json to point to the folder containing your built application.'
-				);
-				return undefined;
-			}
-
-			const exesInFolder = await glob('*.exe', { cwd: resolvedFolder, absolute: true, nocase: true });
-			if (exesInFolder.length === 0) {
-				vscode.window.showErrorMessage(
-					`The configured "inputFolder" does not contain any .exe files: ${inputFolder}. ` +
-					'Build your project first, or update "inputFolder" in launch.json to point to the folder containing your built application.'
-				);
+			const result = await validateInputFolder(inputFolder, cwd);
+			if (!result.valid) {
+				vscode.window.showErrorMessage(result.message);
 				return undefined;
 			}
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -745,11 +745,16 @@ class WinAppDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory 
 			// If not set in launch.json, search for folders containing .exe
 			// files and let the user pick one.
 			let inputFolder: string | undefined = config.inputFolder;
+			let cwd = folder.uri.fsPath;
+			if (config.workingDirectory) {
+				cwd = config.workingDirectory;
+			}
 
 			// Validate a user-specified inputFolder before proceeding.
 			if (inputFolder) {
-				const folderExists = await fs.promises.access(inputFolder).then(() => true, () => false);
-				if (!folderExists) {
+				const resolvedFolder = path.isAbsolute(inputFolder) ? inputFolder : path.resolve(cwd, inputFolder);
+				const folderStat = await fs.promises.stat(resolvedFolder).catch(() => undefined);
+				if (!folderStat) {
 					vscode.window.showErrorMessage(
 						`The configured "inputFolder" path does not exist: ${inputFolder}. ` +
 						'Build your project first, or update "inputFolder" in launch.json to point to your build output directory.'
@@ -757,7 +762,15 @@ class WinAppDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory 
 					return new vscode.DebugAdapterInlineImplementation(new NoOpDebugAdapter());
 				}
 
-				const exesInFolder = await glob('*.exe', { cwd: inputFolder, absolute: true, nocase: true });
+				if (!folderStat.isDirectory()) {
+					vscode.window.showErrorMessage(
+						`The configured "inputFolder" is not a directory: ${inputFolder}. ` +
+						'Update "inputFolder" in launch.json to point to the folder containing your built application.'
+					);
+					return new vscode.DebugAdapterInlineImplementation(new NoOpDebugAdapter());
+				}
+
+				const exesInFolder = await glob('*.exe', { cwd: resolvedFolder, absolute: true, nocase: true });
 				if (exesInFolder.length === 0) {
 					vscode.window.showErrorMessage(
 						`The configured "inputFolder" does not contain any .exe files: ${inputFolder}. ` +
@@ -846,11 +859,6 @@ class WinAppDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory 
 				cancellable: false
 			}, async (progress) => {
 				progress.report({ message: 'Running winapp run...' });
-
-				let cwd = folder.uri.fsPath;
-				if (config.workingDirectory) {
-					cwd = config.workingDirectory;
-				}
 
 				return new Promise<{ processId: number; runProcess: ReturnType<typeof spawn> }>((resolve, reject) => {
 					const child = spawn(cliPath, baseSpawnArgs, {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -718,6 +718,43 @@ class WinAppDebugConfigurationProvider implements vscode.DebugConfigurationProvi
 			return undefined;
 		}
 
+		// Validate a user-specified inputFolder early so we can cleanly
+		// cancel the session (return undefined) before the adapter factory
+		// runs — this avoids showing the debugger toolbar on failure.
+		const inputFolder: string | undefined = config.inputFolder;
+		if (inputFolder) {
+			let cwd = folder.uri.fsPath;
+			if (config.workingDirectory) {
+				cwd = config.workingDirectory;
+			}
+			const resolvedFolder = path.isAbsolute(inputFolder) ? inputFolder : path.resolve(cwd, inputFolder);
+			const folderStat = await fs.promises.stat(resolvedFolder).catch(() => undefined);
+			if (!folderStat) {
+				vscode.window.showErrorMessage(
+					`The configured "inputFolder" path does not exist: ${inputFolder}. ` +
+					'Build your project first, or update "inputFolder" in launch.json to point to your build output directory.'
+				);
+				return undefined;
+			}
+
+			if (!folderStat.isDirectory()) {
+				vscode.window.showErrorMessage(
+					`The configured "inputFolder" is not a directory: ${inputFolder}. ` +
+					'Update "inputFolder" in launch.json to point to the folder containing your built application.'
+				);
+				return undefined;
+			}
+
+			const exesInFolder = await glob('*.exe', { cwd: resolvedFolder, absolute: true, nocase: true });
+			if (exesInFolder.length === 0) {
+				vscode.window.showErrorMessage(
+					`The configured "inputFolder" does not contain any .exe files: ${inputFolder}. ` +
+					'Build your project first, or update "inputFolder" in launch.json to point to the folder containing your built application.'
+				);
+				return undefined;
+			}
+		}
+
 		return config;
 	}
 }
@@ -748,36 +785,6 @@ class WinAppDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory 
 			let cwd = folder.uri.fsPath;
 			if (config.workingDirectory) {
 				cwd = config.workingDirectory;
-			}
-
-			// Validate a user-specified inputFolder before proceeding.
-			if (inputFolder) {
-				const resolvedFolder = path.isAbsolute(inputFolder) ? inputFolder : path.resolve(cwd, inputFolder);
-				const folderStat = await fs.promises.stat(resolvedFolder).catch(() => undefined);
-				if (!folderStat) {
-					vscode.window.showErrorMessage(
-						`The configured "inputFolder" path does not exist: ${inputFolder}. ` +
-						'Build your project first, or update "inputFolder" in launch.json to point to your build output directory.'
-					);
-					return new vscode.DebugAdapterInlineImplementation(new NoOpDebugAdapter());
-				}
-
-				if (!folderStat.isDirectory()) {
-					vscode.window.showErrorMessage(
-						`The configured "inputFolder" is not a directory: ${inputFolder}. ` +
-						'Update "inputFolder" in launch.json to point to the folder containing your built application.'
-					);
-					return new vscode.DebugAdapterInlineImplementation(new NoOpDebugAdapter());
-				}
-
-				const exesInFolder = await glob('*.exe', { cwd: resolvedFolder, absolute: true, nocase: true });
-				if (exesInFolder.length === 0) {
-					vscode.window.showErrorMessage(
-						`The configured "inputFolder" does not contain any .exe files: ${inputFolder}. ` +
-						'Build your project first, or update "inputFolder" in launch.json to point to the folder containing your built application.'
-					);
-					return new vscode.DebugAdapterInlineImplementation(new NoOpDebugAdapter());
-				}
 			}
 
 			if (!inputFolder) {

--- a/src/test/debugger-resolver.test.ts
+++ b/src/test/debugger-resolver.test.ts
@@ -1,10 +1,14 @@
-import { describe, it } from 'node:test';
+import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
 import {
 	DEBUGGER_CHOICE_LABELS,
 	chooseInstalledDebuggerType,
 	getDebuggerExtensionRequirement,
-	getDebuggerTypeFromChoice
+	getDebuggerTypeFromChoice,
+	validateInputFolder
 } from '../debugger-resolver';
 
 describe('debugger resolver helpers', () => {
@@ -64,5 +68,72 @@ describe('debugger resolver helpers', () => {
 			assert.equal(getDebuggerTypeFromChoice(undefined), undefined);
 			assert.equal(getDebuggerTypeFromChoice('Cancel'), undefined);
 		});
+	});
+});
+
+describe('validateInputFolder', () => {
+	let tmpDir: string;
+	let validDir: string;
+	let emptyDir: string;
+	let aFile: string;
+
+	before(async () => {
+		tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'inputfolder-test-'));
+		validDir = path.join(tmpDir, 'with-exe');
+		emptyDir = path.join(tmpDir, 'no-exe');
+		await fs.promises.mkdir(validDir);
+		await fs.promises.mkdir(emptyDir);
+		await fs.promises.writeFile(path.join(validDir, 'MyApp.exe'), '');
+		aFile = path.join(tmpDir, 'not-a-dir.txt');
+		await fs.promises.writeFile(aFile, 'hello');
+	});
+
+	after(async () => {
+		await fs.promises.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it('returns valid for a directory containing an .exe file', async () => {
+		const result = await validateInputFolder(validDir, tmpDir);
+		assert.equal(result.valid, true);
+	});
+
+	it('returns not-found when the path does not exist', async () => {
+		const result = await validateInputFolder('C:\\does\\not\\exist', tmpDir);
+		assert.equal(result.valid, false);
+		if (!result.valid) {
+			assert.equal(result.reason, 'not-found');
+			assert.match(result.message, /does not exist/);
+		}
+	});
+
+	it('returns not-directory when the path is a file', async () => {
+		const result = await validateInputFolder(aFile, tmpDir);
+		assert.equal(result.valid, false);
+		if (!result.valid) {
+			assert.equal(result.reason, 'not-directory');
+			assert.match(result.message, /not a directory/);
+		}
+	});
+
+	it('returns no-exe when the directory has no .exe files', async () => {
+		const result = await validateInputFolder(emptyDir, tmpDir);
+		assert.equal(result.valid, false);
+		if (!result.valid) {
+			assert.equal(result.reason, 'no-exe');
+			assert.match(result.message, /does not contain any \.exe files/);
+		}
+	});
+
+	it('resolves relative paths against the provided cwd', async () => {
+		const result = await validateInputFolder('with-exe', tmpDir);
+		assert.equal(result.valid, true);
+	});
+
+	it('rejects relative paths that do not exist against the cwd', async () => {
+		const result = await validateInputFolder('nonexistent-subdir', tmpDir);
+		assert.equal(result.valid, false);
+		if (!result.valid) {
+			assert.equal(result.reason, 'not-found');
+		}
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #33 — F5 silently falls back to a native folder picker when `launch.json`'s `inputFolder` is invalid.

## Changes

When `inputFolder` is configured in `launch.json`, the debug adapter now validates it before proceeding:

1. **Path doesn't exist** → clear error message, debug session aborts
2. **Path is not a directory** → clear error message, debug session aborts  
3. **Path exists but contains no `.exe` files** → clear error message, debug session aborts

The validation resolves relative paths against the effective debug session `cwd` (workspace folder or `workingDirectory`) so relative `inputFolder` values work correctly.

## Before

Invalid `inputFolder` would silently pass through to the CLI, causing confusing failures or unexpected folder picker dialogs.

## After

Users see a clear error explaining what's wrong and how to fix it (build the project or update `launch.json`).

## Testing

- Live tested with the vsce-testing harness: set `inputFolder` to a nonexistent path, pressed F5, confirmed the error notification appears and no folder picker dialog is shown.
- Build passes (`npm run compile`).

## Related issues filed

- #110 — Docs: inputFolder description doesn't document validation behavior
- #111 — Add "Open launch.json" action button to inputFolder validation errors
- #112 — Relative workingDirectory resolves against extension host cwd (pre-existing)