### PR TITLE
Replace native OS folder pickers in pack/run with in-editor QuickPicks

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,6 @@ import {
 } from './winapp-cli-utils';
 import { detectProjects } from './project-detection';
 import { resolveProjectDirectory as resolveProjectDirectoryCore } from './project-resolver';
-import { glob } from 'glob';
 import { ManifestEditorProvider } from './manifest-editor/manifest-editor-provider';
 import {
 	PACK_ACTIONS,
@@ -444,13 +443,12 @@ const BUILD_OUTPUT_SEARCH_MAX_DEPTH = 8;
 const BUILD_OUTPUT_EXCLUDE_GLOB = '{**/node_modules/**,**/.git/**,**/AppX/**,**/.winapp/**,**/obj/**,**/.vs/**,**/packages/**}';
 
 /**
- * Search the workspace for build output folders (directories containing .exe
- * files) and let the user pick one via a QuickPick. Falls back to a native
- * folder dialog when none are found; a "Browse…" entry is always appended.
+ * Scan the workspace for build output folders (directories containing .exe
+ * files). Shows a progress notification with cancel support.
  *
- * @returns The selected folder path, or `undefined` if cancelled.
+ * @returns The discovered folder paths sorted by relative path, or undefined if cancelled.
  */
-async function pickBuildOutputFolder(workspacePath: string): Promise<string | undefined> {
+async function findBuildOutputFolders(workspacePath: string): Promise<string[] | undefined> {
 	let cancelled = false;
 	const outputFolders = await vscode.window.withProgress(
 		{ location: vscode.ProgressLocation.Notification, title: 'Searching for build output folders...', cancellable: true },
@@ -479,6 +477,22 @@ async function pickBuildOutputFolder(workspacePath: string): Promise<string | un
 	);
 
 	if (cancelled) {
+		return undefined;
+	}
+
+	return outputFolders;
+}
+
+/**
+ * Search the workspace for build output folders and let the user pick one via
+ * a QuickPick. Falls back to a native folder dialog when none are found; a
+ * "Browse…" entry is always appended.
+ *
+ * @returns The selected folder path, or `undefined` if cancelled.
+ */
+async function pickBuildOutputFolder(workspacePath: string): Promise<string | undefined> {
+	const outputFolders = await findBuildOutputFolders(workspacePath);
+	if (!outputFolders) {
 		return undefined;
 	}
 
@@ -841,24 +855,12 @@ class WinAppDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory 
 			// files and let the user pick one.
 			let inputFolder: string | undefined = config.inputFolder;
 			if (!inputFolder) {
-				const exeMatches = await glob('**/*.exe', {
-					cwd: folder.uri.fsPath,
-					absolute: true,
-					nocase: true,
-					ignore: ['**/node_modules/**', '**/.git/**', '**/AppX/**', '**/.winapp/**', '**/obj/**', '**/.vs/**', '**/packages/**']
-				});
+				const dirs = await findBuildOutputFolders(folder.uri.fsPath);
 
-				// Collect unique parent directories that contain .exe files
-				const dirSet = new Set<string>();
-				for (const exe of exeMatches) {
-					dirSet.add(path.dirname(exe));
-				}
-
-				if (dirSet.size === 0) {
+				if (!dirs || dirs.length === 0) {
 					throw new Error('No folders containing .exe files found in the workspace. Build your project first, or set "inputFolder" in launch.json.');
 				}
 
-				const dirs = [...dirSet].sort();
 				if (dirs.length === 1) {
 					inputFolder = dirs[0];
 				} else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -483,7 +483,7 @@ async function pickBuildOutputFolder(workspacePath: string): Promise<string | un
 	}
 
 	if (outputFolders.length === 0) {
-		return selectFolder('Select build output folder');
+		return selectFolder('Select build output folder', vscode.Uri.file(workspacePath));
 	}
 
 	const items: Array<vscode.QuickPickItem & { directory?: string }> = outputFolders.map((folderPath) => ({
@@ -503,7 +503,7 @@ async function pickBuildOutputFolder(workspacePath: string): Promise<string | un
 	}
 
 	if (picked.detail === FOLDER_PICKER_DETAIL) {
-		return selectFolder('Select build output folder');
+		return selectFolder('Select build output folder', vscode.Uri.file(workspacePath));
 	}
 
 	return picked.directory;
@@ -698,7 +698,7 @@ async function resolveProjectDirectory(workspacePath: string): Promise<string | 
 			const picked = await vscode.window.showQuickPick([...items, browseItem], { placeHolder });
 			if (!picked) { return undefined; }
 			if (picked.directory === '') {
-				const folder = await selectFolder('Select project folder');
+				const folder = await selectFolder('Select project folder', vscode.Uri.file(workspacePath));
 				if (!folder) { return undefined; }
 				const relative = path.relative(workspacePath, folder);
 				if (relative.startsWith('..') || path.isAbsolute(relative)) {
@@ -758,12 +758,13 @@ async function selectFile(title: string, filters?: { [name: string]: string[] })
 /**
  * Prompt user to select a folder
  */
-async function selectFolder(title: string): Promise<string | undefined> {
+async function selectFolder(title: string, defaultUri?: vscode.Uri): Promise<string | undefined> {
 	const result = await vscode.window.showOpenDialog({
 		canSelectFiles: false,
 		canSelectFolders: true,
 		canSelectMany: false,
-		title: title
+		title: title,
+		defaultUri: defaultUri
 	});
 
 	return result?.[0]?.fsPath;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@ import {
 	isUsableElevatedCliPath,
 	decideElevatedWinappCommand
 } from './winapp-cli-utils';
-import { detectProjects } from './project-detection';
+import { detectProjects, deduplicateBuildOutputFolders, BUILD_OUTPUT_EXCLUDE_GLOB, BUILD_OUTPUT_MAX_RESULTS } from './project-detection';
 import { resolveProjectDirectory as resolveProjectDirectoryCore } from './project-resolver';
 import { ManifestEditorProvider } from './manifest-editor/manifest-editor-provider';
 import {
@@ -438,9 +438,6 @@ async function pickCertificateFile(workspacePath: string): Promise<string | unde
 }
 
 const FOLDER_PICKER_DETAIL = 'Open a folder picker';
-const BUILD_OUTPUT_SEARCH_MAX_RESULTS = 10;
-const BUILD_OUTPUT_SEARCH_MAX_DEPTH = 8;
-const BUILD_OUTPUT_EXCLUDE_GLOB = '{**/node_modules/**,**/.git/**,**/AppX/**,**/.winapp/**,**/obj/**,**/.vs/**,**/packages/**}';
 
 /**
  * Scan the workspace for build output folders (directories containing .exe
@@ -457,21 +454,12 @@ async function findBuildOutputFolders(workspacePath: string): Promise<string[] |
 			const exeMatches = await vscode.workspace.findFiles(
 				new vscode.RelativePattern(workspacePath, '**/*.exe'),
 				BUILD_OUTPUT_EXCLUDE_GLOB,
-				BUILD_OUTPUT_SEARCH_MAX_RESULTS
+				BUILD_OUTPUT_MAX_RESULTS
 			);
 
-			const folderSet = new Set<string>();
-			for (const match of exeMatches) {
-				const folderPath = path.dirname(match.fsPath);
-				const relativeFolder = path.relative(workspacePath, folderPath);
-				if (relativeFolder !== '' && relativeFolder.split(path.sep).length > BUILD_OUTPUT_SEARCH_MAX_DEPTH) {
-					continue;
-				}
-				folderSet.add(folderPath);
-			}
-
-			return [...folderSet].sort((left, right) =>
-				path.relative(workspacePath, left).localeCompare(path.relative(workspacePath, right))
+			return deduplicateBuildOutputFolders(
+				exeMatches.map(m => m.fsPath),
+				workspacePath
 			);
 		}
 	);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -438,6 +438,77 @@ async function pickCertificateFile(workspacePath: string): Promise<string | unde
 	return picked.detail;
 }
 
+const FOLDER_PICKER_DETAIL = 'Open a folder picker';
+const BUILD_OUTPUT_SEARCH_MAX_RESULTS = 200;
+const BUILD_OUTPUT_SEARCH_MAX_DEPTH = 8;
+const BUILD_OUTPUT_EXCLUDE_GLOB = '{**/node_modules/**,**/.git/**,**/AppX/**,**/.winapp/**,**/obj/**,**/.vs/**,**/packages/**}';
+
+/**
+ * Search the workspace for build output folders (directories containing .exe
+ * files) and let the user pick one via a QuickPick. Falls back to a native
+ * folder dialog when none are found; a "Browse…" entry is always appended.
+ *
+ * @returns The selected folder path, or `undefined` if cancelled.
+ */
+async function pickBuildOutputFolder(workspacePath: string): Promise<string | undefined> {
+	let cancelled = false;
+	const outputFolders = await vscode.window.withProgress(
+		{ location: vscode.ProgressLocation.Notification, title: 'Searching for build output folders...', cancellable: true },
+		async (_progress, token) => {
+			token.onCancellationRequested(() => { cancelled = true; });
+			const exeMatches = await vscode.workspace.findFiles(
+				new vscode.RelativePattern(workspacePath, '**/*.exe'),
+				BUILD_OUTPUT_EXCLUDE_GLOB,
+				BUILD_OUTPUT_SEARCH_MAX_RESULTS
+			);
+
+			const folderSet = new Set<string>();
+			for (const match of exeMatches) {
+				const folderPath = path.dirname(match.fsPath);
+				const relativeFolder = path.relative(workspacePath, folderPath);
+				if (relativeFolder !== '' && relativeFolder.split(path.sep).length > BUILD_OUTPUT_SEARCH_MAX_DEPTH) {
+					continue;
+				}
+				folderSet.add(folderPath);
+			}
+
+			return [...folderSet].sort((left, right) =>
+				path.relative(workspacePath, left).localeCompare(path.relative(workspacePath, right))
+			);
+		}
+	);
+
+	if (cancelled) {
+		return undefined;
+	}
+
+	if (outputFolders.length === 0) {
+		return selectFolder('Select build output folder');
+	}
+
+	const items: Array<vscode.QuickPickItem & { directory?: string }> = outputFolders.map((folderPath) => ({
+		label: path.relative(workspacePath, folderPath) || '.',
+		detail: folderPath,
+		directory: folderPath
+	}));
+
+	items.push({ label: '$(folder-opened) Browse…', detail: FOLDER_PICKER_DETAIL });
+
+	const picked = await vscode.window.showQuickPick(items, {
+		placeHolder: 'Select the build output folder containing your app'
+	});
+
+	if (!picked) {
+		return undefined;
+	}
+
+	if (picked.detail === FOLDER_PICKER_DETAIL) {
+		return selectFolder('Select build output folder');
+	}
+
+	return picked.directory;
+}
+
 /**
  * Run the code-signing flow for an MSIX/executable. Prompts for the file to
  * sign (unless one is supplied) and the signing certificate, then invokes
@@ -623,11 +694,11 @@ async function resolveProjectDirectory(workspacePath: string): Promise<string | 
 			vscode.window.showWarningMessage(message);
 		},
 		pickDirectory: async (items, placeHolder) => {
-			const browseItem = { label: '$(folder-opened) Browse…', description: 'Open a folder picker', directory: '' };
+			const browseItem = { label: '$(folder-opened) Browse…', detail: FOLDER_PICKER_DETAIL, directory: '' };
 			const picked = await vscode.window.showQuickPick([...items, browseItem], { placeHolder });
 			if (!picked) { return undefined; }
-			if (picked === browseItem) { return selectFolder('Select project folder'); }
-			return picked.directory;
+			if (picked.detail === FOLDER_PICKER_DETAIL) { return selectFolder('Select project folder'); }
+			return picked.directory || undefined;
 		},
 		scanProjects: async (root) =>
 			vscode.window.withProgress(
@@ -1078,7 +1149,7 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
-			const inputFolder = await resolveProjectDirectory(workspacePath);
+			const inputFolder = await pickBuildOutputFolder(workspacePath);
 			if (!inputFolder) {
 				return;
 			}
@@ -1139,7 +1210,7 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
-			const inputFolder = await resolveProjectDirectory(workspacePath);
+			const inputFolder = await pickBuildOutputFolder(workspacePath);
 			if (!inputFolder) {
 				return;
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -705,6 +705,17 @@ async function resolveProjectDirectory(workspacePath: string): Promise<string | 
 					vscode.window.showWarningMessage('Selected folder is outside the workspace and was ignored.');
 					return undefined;
 				}
+				try {
+					const realWorkspace = await fs.promises.realpath(workspacePath);
+					const realFolder = await fs.promises.realpath(folder);
+					const realRelative = path.relative(realWorkspace, realFolder);
+					if (realRelative.startsWith('..') || path.isAbsolute(realRelative)) {
+						vscode.window.showWarningMessage('Selected folder is outside the workspace and was ignored.');
+						return undefined;
+					}
+				} catch {
+					// Target doesn't exist on disk — lexical check above is authoritative
+				}
 				return folder;
 			}
 			return picked.directory || undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -697,7 +697,16 @@ async function resolveProjectDirectory(workspacePath: string): Promise<string | 
 			const browseItem = { label: '$(folder-opened) Browse…', detail: FOLDER_PICKER_DETAIL, directory: '' };
 			const picked = await vscode.window.showQuickPick([...items, browseItem], { placeHolder });
 			if (!picked) { return undefined; }
-			if (picked.detail === FOLDER_PICKER_DETAIL) { return selectFolder('Select project folder'); }
+			if (picked.detail === FOLDER_PICKER_DETAIL) {
+				const folder = await selectFolder('Select project folder');
+				if (!folder) { return undefined; }
+				const relative = path.relative(workspacePath, folder);
+				if (relative.startsWith('..') || path.isAbsolute(relative)) {
+					vscode.window.showWarningMessage('Selected folder is outside the workspace and was ignored.');
+					return undefined;
+				}
+				return folder;
+			}
 			return picked.directory || undefined;
 		},
 		scanProjects: async (root) =>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -439,7 +439,7 @@ async function pickCertificateFile(workspacePath: string): Promise<string | unde
 }
 
 const FOLDER_PICKER_DETAIL = 'Open a folder picker';
-const BUILD_OUTPUT_SEARCH_MAX_RESULTS = 200;
+const BUILD_OUTPUT_SEARCH_MAX_RESULTS = 10;
 const BUILD_OUTPUT_SEARCH_MAX_DEPTH = 8;
 const BUILD_OUTPUT_EXCLUDE_GLOB = '{**/node_modules/**,**/.git/**,**/AppX/**,**/.winapp/**,**/obj/**,**/.vs/**,**/packages/**}';
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -623,8 +623,11 @@ async function resolveProjectDirectory(workspacePath: string): Promise<string | 
 			vscode.window.showWarningMessage(message);
 		},
 		pickDirectory: async (items, placeHolder) => {
-			const picked = await vscode.window.showQuickPick(items, { placeHolder });
-			return picked?.directory;
+			const browseItem = { label: '$(folder-opened) Browse…', description: 'Open a folder picker', directory: '' };
+			const picked = await vscode.window.showQuickPick([...items, browseItem], { placeHolder });
+			if (!picked) { return undefined; }
+			if (picked === browseItem) { return selectFolder('Select project folder'); }
+			return picked.directory;
 		},
 		scanProjects: async (root) =>
 			vscode.window.withProgress(
@@ -1075,7 +1078,7 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
-			const inputFolder = await selectFolder('Select input folder to package');
+			const inputFolder = await resolveProjectDirectory(workspacePath);
 			if (!inputFolder) {
 				return;
 			}
@@ -1136,7 +1139,7 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
-			const inputFolder = await selectFolder('Select input folder containing the app to run');
+			const inputFolder = await resolveProjectDirectory(workspacePath);
 			if (!inputFolder) {
 				return;
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -697,7 +697,7 @@ async function resolveProjectDirectory(workspacePath: string): Promise<string | 
 			const browseItem = { label: '$(folder-opened) Browse…', detail: FOLDER_PICKER_DETAIL, directory: '' };
 			const picked = await vscode.window.showQuickPick([...items, browseItem], { placeHolder });
 			if (!picked) { return undefined; }
-			if (picked.detail === FOLDER_PICKER_DETAIL) {
+			if (picked.directory === '') {
 				const folder = await selectFolder('Select project folder');
 				if (!folder) { return undefined; }
 				const relative = path.relative(workspacePath, folder);

--- a/src/project-detection.ts
+++ b/src/project-detection.ts
@@ -132,6 +132,54 @@ export async function detectProjects(root: string, maxProjects: number = 10): Pr
 	return results;
 }
 
+/** Directories to exclude from build-output scanning. */
+export const BUILD_OUTPUT_SKIP_DIRS = new Set([
+	'node_modules', '.git', 'appx', '.winapp', 'obj', '.vs', 'packages'
+]);
+
+/**
+ * Maximum depth (in path segments relative to root) for build-output results.
+ */
+export const BUILD_OUTPUT_MAX_DEPTH = 8;
+
+/**
+ * Maximum number of executable matches to consider before stopping.
+ */
+export const BUILD_OUTPUT_MAX_RESULTS = 10;
+
+/**
+ * Given a list of absolute file paths (typically .exe matches) and a workspace
+ * root, returns the unique parent directories sorted by relative path. Filters
+ * out directories deeper than `maxDepth` segments from the root.
+ *
+ * This is the pure logic extracted from the VS Code build-output scan so it
+ * can be unit tested without the VS Code API.
+ */
+export function deduplicateBuildOutputFolders(
+	filePaths: string[],
+	workspacePath: string,
+	maxDepth: number = BUILD_OUTPUT_MAX_DEPTH
+): string[] {
+	const folderSet = new Set<string>();
+	for (const filePath of filePaths) {
+		const folderPath = path.dirname(filePath);
+		const relativeFolder = path.relative(workspacePath, folderPath);
+		if (relativeFolder !== '' && relativeFolder.split(path.sep).length > maxDepth) {
+			continue;
+		}
+		folderSet.add(folderPath);
+	}
+
+	return [...folderSet].sort((left, right) =>
+		path.relative(workspacePath, left).localeCompare(path.relative(workspacePath, right))
+	);
+}
+
+/**
+ * VS Code-compatible glob exclude pattern for build-output scanning.
+ */
+export const BUILD_OUTPUT_EXCLUDE_GLOB = `{${[...BUILD_OUTPUT_SKIP_DIRS].map(d => `**/${d}/**`).join(',')}}`;
+
 async function fileExists(filePath: string): Promise<boolean> {
 	try {
 		await fsp.access(filePath);

--- a/src/test/project-detection.test.ts
+++ b/src/test/project-detection.test.ts
@@ -7,7 +7,9 @@ import {
 	detectProjects,
 	getProjectLabel,
 	getDisplayFilePath,
-	DetectedProject
+	DetectedProject,
+	deduplicateBuildOutputFolders,
+	BUILD_OUTPUT_MAX_DEPTH
 } from '../project-detection';
 
 /**
@@ -306,6 +308,78 @@ describe('project-detection', () => {
 				projectFileName: 'App.csproj'
 			};
 			assert.strictEqual(getProjectLabel(project), '.NET project (./src/app/App.csproj)');
+		});
+	});
+
+	describe('deduplicateBuildOutputFolders', () => {
+		const sep = path.sep;
+		const root = process.platform === 'win32' ? 'C:\\workspace' : '/workspace';
+
+		it('deduplicates files in the same directory', () => {
+			const files = [
+				path.join(root, 'bin', 'Debug', 'app.exe'),
+				path.join(root, 'bin', 'Debug', 'helper.exe')
+			];
+			const result = deduplicateBuildOutputFolders(files, root);
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0], path.join(root, 'bin', 'Debug'));
+		});
+
+		it('returns multiple folders for files in different directories', () => {
+			const files = [
+				path.join(root, 'bin', 'Debug', 'app.exe'),
+				path.join(root, 'bin', 'Release', 'app.exe')
+			];
+			const result = deduplicateBuildOutputFolders(files, root);
+			assert.strictEqual(result.length, 2);
+			assert.ok(result.includes(path.join(root, 'bin', 'Debug')));
+			assert.ok(result.includes(path.join(root, 'bin', 'Release')));
+		});
+
+		it('filters out directories exceeding max depth', () => {
+			// Build a path that exceeds the depth limit
+			const segments = Array.from({ length: BUILD_OUTPUT_MAX_DEPTH + 1 }, (_, i) => `d${i}`);
+			const deepPath = path.join(root, ...segments, 'app.exe');
+			const shallowPath = path.join(root, 'bin', 'app.exe');
+			const result = deduplicateBuildOutputFolders([deepPath, shallowPath], root);
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0], path.join(root, 'bin'));
+		});
+
+		it('respects custom maxDepth parameter', () => {
+			const files = [
+				path.join(root, 'a', 'b', 'c', 'app.exe'),  // depth 3
+				path.join(root, 'x', 'app.exe')              // depth 1
+			];
+			const result = deduplicateBuildOutputFolders(files, root, 2);
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0], path.join(root, 'x'));
+		});
+
+		it('returns empty array for no input', () => {
+			const result = deduplicateBuildOutputFolders([], root);
+			assert.strictEqual(result.length, 0);
+		});
+
+		it('sorts results by relative path', () => {
+			const files = [
+				path.join(root, 'z-app', 'app.exe'),
+				path.join(root, 'a-app', 'app.exe'),
+				path.join(root, 'm-app', 'app.exe')
+			];
+			const result = deduplicateBuildOutputFolders(files, root);
+			assert.deepStrictEqual(result, [
+				path.join(root, 'a-app'),
+				path.join(root, 'm-app'),
+				path.join(root, 'z-app')
+			]);
+		});
+
+		it('includes files at workspace root (depth 0)', () => {
+			const files = [path.join(root, 'app.exe')];
+			const result = deduplicateBuildOutputFolders(files, root);
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0], root);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Replaces the native OS folder dialogs in `winapp.pack` and `winapp.run` with in-editor QuickPick-based selection, addressing #39 (folder picker portion).

## Changes

### New: `pickBuildOutputFolder()` function
- Scans the workspace for folders containing `.exe` files (build output directories)
- Presents results in a QuickPick with relative path labels
- Always appends a **"Browse…"** fallback that opens the native folder dialog
- Falls back directly to the native dialog when no `.exe` folders are found
- Wraps the scan in `withProgress` with cancel support
- Excludes irrelevant directories (`node_modules`, `.git`, `AppX`, `.winapp`, `obj`, `.vs`, `packages`)

### Updated: `pickDirectory` wrapper in `resolveProjectDirectory`
- Adds a **"Browse…"** item to the project QuickPick (consistent with `pickSignableFile`/`pickCertificateFile` patterns)
- Uses sentinel-based detection (`detail` field) instead of object reference equality
- Validates Browse selections stay within the workspace boundary (lexical + realpath check, matching `isContainedInWorkspace` behavior)

### Command changes
- `winapp.pack` → uses `pickBuildOutputFolder(workspacePath)` instead of `selectFolder(...)`
- `winapp.run` → uses `pickBuildOutputFolder(workspacePath)` instead of `selectFolder(...)`

## Design decisions

- **Build output picker (not project resolver) for pack/run**: These commands need a build output folder containing `.exe` files, not a project source directory. The README explicitly documents this distinction.
- **Browse always available**: When the scan finds results, Browse is in the QuickPick. When it finds nothing, it falls back directly to the native dialog — the user is never stuck.
- **Workspace boundary enforcement**: The project picker's Browse validates containment using both lexical and realpath checks to prevent symlink/junction escapes.

## Testing

- `npm run compile` ✅
- `npx tsx --test src/test/project-resolver.test.ts` — 13/13 tests pass ✅

Fixes #39 (folder picker portion)