### PR TITLE
Use cancellable VS Code search for signing artifacts

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,13 @@ import {
 	isArtifactWithinRoot,
 	planPackCompletion
 } from './pack-result';
-import { findWorkspaceArtifacts, buildSignCommand, CERTIFICATE_GLOBS, executeSignFlow, type SignFlowAdapter } from './sign-utils';
+import {
+	findWorkspaceArtifacts,
+	buildSignCommand,
+	CERTIFICATE_GLOBS,
+	executeSignFlow,
+	type SignFlowAdapter
+} from './sign-utils';
 import { ARTIFACT_DIALOG_FILTER, ARTIFACT_GLOBS } from './artifact-types';
 import {
 	detectArchFromPath,
@@ -333,18 +339,15 @@ async function runWinappCapture(
  * @returns The selected file path, or `undefined` if cancelled.
  */
 async function pickSignableFile(workspacePath: string): Promise<string | undefined> {
-	let cancelled = false;
-	const artifactPaths = await vscode.window.withProgress(
+	const discovery = await vscode.window.withProgress(
 		{ location: vscode.ProgressLocation.Notification, title: 'Searching for signable artifacts...', cancellable: true },
-		async (_progress, token) => {
-			token.onCancellationRequested(() => { cancelled = true; });
-			return findWorkspaceArtifacts(workspacePath, ARTIFACT_GLOBS);
-		}
+		(_progress, token) => findWorkspaceArtifactsWithCancellation(workspacePath, ARTIFACT_GLOBS, token)
 	);
 
-	if (cancelled) {
+	if (discovery.cancelled) {
 		return undefined;
 	}
+	const artifactPaths = discovery.paths;
 
 	if (artifactPaths.length === 0) {
 		return selectFile('Select file to sign', {
@@ -392,18 +395,15 @@ async function pickSignableFile(workspacePath: string): Promise<string | undefin
  * @returns The selected certificate path, or `undefined` if cancelled.
  */
 async function pickCertificateFile(workspacePath: string): Promise<string | undefined> {
-	let cancelled = false;
-	const certPaths = await vscode.window.withProgress(
+	const discovery = await vscode.window.withProgress(
 		{ location: vscode.ProgressLocation.Notification, title: 'Searching for certificates...', cancellable: true },
-		async (_progress, token) => {
-			token.onCancellationRequested(() => { cancelled = true; });
-			return findWorkspaceArtifacts(workspacePath, CERTIFICATE_GLOBS);
-		}
+		(_progress, token) => findWorkspaceArtifactsWithCancellation(workspacePath, CERTIFICATE_GLOBS, token)
 	);
 
-	if (cancelled) {
+	if (discovery.cancelled) {
 		return undefined;
 	}
+	const certPaths = discovery.paths;
 
 	if (certPaths.length === 0) {
 		return selectFile('Select signing certificate', {
@@ -437,6 +437,41 @@ async function pickCertificateFile(workspacePath: string): Promise<string | unde
 	}
 
 	return picked.detail;
+}
+
+async function findWorkspaceArtifactsWithCancellation(
+	workspacePath: string,
+	patterns: string[],
+	token: vscode.CancellationToken
+): Promise<{ paths: string[]; cancelled: boolean }> {
+	const abortController = new AbortController();
+	const cancellation = token.onCancellationRequested(() => abortController.abort());
+	if (token.isCancellationRequested) {
+		abortController.abort();
+	}
+
+	try {
+		const paths = await findWorkspaceArtifacts(
+			workspacePath,
+			async (includePattern, signal) => {
+				if (signal?.aborted) {
+					return [];
+				}
+				const matches = await vscode.workspace.findFiles(
+					new vscode.RelativePattern(workspacePath, includePattern),
+					null,
+					undefined,
+					token
+				);
+				return matches.map(uri => uri.fsPath);
+			},
+			patterns,
+			abortController.signal
+		);
+		return { paths, cancelled: token.isCancellationRequested };
+	} finally {
+		cancellation.dispose();
+	}
 }
 
 const FOLDER_PICKER_DETAIL = 'Open a folder picker';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -339,15 +339,14 @@ async function runWinappCapture(
  * @returns The selected file path, or `undefined` if cancelled.
  */
 async function pickSignableFile(workspacePath: string): Promise<string | undefined> {
-	const discovery = await vscode.window.withProgress(
+	const artifactPaths = await vscode.window.withProgress(
 		{ location: vscode.ProgressLocation.Notification, title: 'Searching for signable artifacts...', cancellable: true },
 		(_progress, token) => findWorkspaceArtifactsWithCancellation(workspacePath, ARTIFACT_GLOBS, token)
 	);
 
-	if (discovery.cancelled) {
+	if (!artifactPaths) {
 		return undefined;
 	}
-	const artifactPaths = discovery.paths;
 
 	if (artifactPaths.length === 0) {
 		return selectFile('Select file to sign', {
@@ -395,15 +394,14 @@ async function pickSignableFile(workspacePath: string): Promise<string | undefin
  * @returns The selected certificate path, or `undefined` if cancelled.
  */
 async function pickCertificateFile(workspacePath: string): Promise<string | undefined> {
-	const discovery = await vscode.window.withProgress(
+	const certPaths = await vscode.window.withProgress(
 		{ location: vscode.ProgressLocation.Notification, title: 'Searching for certificates...', cancellable: true },
 		(_progress, token) => findWorkspaceArtifactsWithCancellation(workspacePath, CERTIFICATE_GLOBS, token)
 	);
 
-	if (discovery.cancelled) {
+	if (!certPaths) {
 		return undefined;
 	}
-	const certPaths = discovery.paths;
 
 	if (certPaths.length === 0) {
 		return selectFile('Select signing certificate', {
@@ -443,7 +441,7 @@ async function findWorkspaceArtifactsWithCancellation(
 	workspacePath: string,
 	patterns: string[],
 	token: vscode.CancellationToken
-): Promise<{ paths: string[]; cancelled: boolean }> {
+): Promise<string[] | undefined> {
 	const abortController = new AbortController();
 	const cancellation = token.onCancellationRequested(() => abortController.abort());
 	if (token.isCancellationRequested) {
@@ -468,7 +466,7 @@ async function findWorkspaceArtifactsWithCancellation(
 			patterns,
 			abortController.signal
 		);
-		return { paths, cancelled: token.isCancellationRequested };
+		return token.isCancellationRequested ? undefined : paths;
 	} finally {
 		cancellation.dispose();
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,19 @@ import {
 	isArtifactWithinRoot,
 	planPackCompletion
 } from './pack-result';
-import { findWorkspaceArtifacts, buildSignCommand, CERTIFICATE_GLOBS, executeSignFlow, type SignFlowAdapter } from './sign-utils';
+import {
+	findWorkspaceArtifacts,
+	buildSignCommand,
+	CERTIFICATE_GLOBS,
+	executeSignFlow,
+	coordinateWorkspaceSignFileSelection,
+	discoverSignFilesWithFallback,
+	runWithCancellation,
+	runWithCancellationSource,
+	type SignFileDiscovery,
+	type SignFlowAdapter,
+	type WorkspaceFileFinder
+} from './sign-utils';
 import { ARTIFACT_DIALOG_FILTER, ARTIFACT_GLOBS } from './artifact-types';
 import {
 	detectArchFromPath,
@@ -326,117 +338,122 @@ async function runWinappCapture(
 
 /**
  * Search the workspace for MSIX/APPX artifacts and let the user pick one via
- * a QuickPick. When no artifacts are found the function falls back directly to
- * a native file dialog; a "Browse…" entry is always appended so the user can
- * opt into the dialog even when artifacts *are* discovered.
+ * a QuickPick. When no artifacts are found the function falls back to a native
+ * file dialog; if the bounded workspace search produced only filtered results,
+ * the handoff is surfaced explicitly first. A "Browse…" entry is always
+ * appended so the user can opt into the dialog even when artifacts *are*
+ * discovered.
  *
  * @returns The selected file path, or `undefined` if cancelled.
  */
 async function pickSignableFile(workspacePath: string): Promise<string | undefined> {
-	let cancelled = false;
-	const artifactPaths = await vscode.window.withProgress(
-		{ location: vscode.ProgressLocation.Notification, title: 'Searching for signable artifacts...', cancellable: true },
-		async (_progress, token) => {
-			token.onCancellationRequested(() => { cancelled = true; });
-			return findWorkspaceArtifacts(workspacePath, ARTIFACT_GLOBS);
-		}
-	);
-
-	if (cancelled) {
-		return undefined;
-	}
-
-	if (artifactPaths.length === 0) {
-		return selectFile('Select file to sign', {
-			...ARTIFACT_DIALOG_FILTER,
-			'Executables': ['exe', 'dll'],
-			'All files': ['*']
-		});
-	}
-
-	const items: vscode.QuickPickItem[] = artifactPaths.map((p) => {
-		const relDir = path.dirname(path.relative(workspacePath, p));
-		return {
-			label: path.basename(p),
-			description: relDir === '.' ? '' : relDir,
-			detail: p
-		};
+	return pickWorkspaceSignFile(workspacePath, {
+		patterns: ARTIFACT_GLOBS,
+		progressTitle: 'Searching for signable artifacts...',
+		searchContext: 'signable artifacts',
+		placeHolder: 'Select a package to sign',
+		selectManualFile: selectArtifactFile
 	});
-
-	items.push({ label: '$(folder-opened) Browse…', detail: 'Open a file picker' });
-
-	const picked = await vscode.window.showQuickPick(items, {
-		placeHolder: 'Select a package to sign'
-	});
-
-	if (!picked) {
-		return undefined;
-	}
-
-	if (picked.detail === 'Open a file picker') {
-		return selectFile('Select file to sign', {
-			...ARTIFACT_DIALOG_FILTER,
-			'Executables': ['exe', 'dll'],
-			'All files': ['*']
-		});
-	}
-
-	return picked.detail;
 }
 
 /**
  * Search the workspace for PFX certificate files and let the user pick one
- * via a QuickPick. Falls back to a native file dialog when none are found;
- * a "Browse…" entry is always appended.
+ * via a QuickPick. Falls back to a native file dialog when none are found; if
+ * the bounded workspace search produced only filtered results, the handoff is
+ * surfaced explicitly first. A "Browse…" entry is always appended.
  *
  * @returns The selected certificate path, or `undefined` if cancelled.
  */
 async function pickCertificateFile(workspacePath: string): Promise<string | undefined> {
-	let cancelled = false;
-	const certPaths = await vscode.window.withProgress(
-		{ location: vscode.ProgressLocation.Notification, title: 'Searching for certificates...', cancellable: true },
-		async (_progress, token) => {
-			token.onCancellationRequested(() => { cancelled = true; });
-			return findWorkspaceArtifacts(workspacePath, CERTIFICATE_GLOBS);
-		}
+	return pickWorkspaceSignFile(workspacePath, {
+		patterns: CERTIFICATE_GLOBS,
+		progressTitle: 'Searching for certificates...',
+		searchContext: 'signing certificates',
+		placeHolder: 'Select a signing certificate',
+		selectManualFile: selectCertificateFile
+	});
+}
+
+interface WorkspaceSignFilePickerOptions {
+	patterns: string[];
+	progressTitle: string;
+	searchContext: string;
+	placeHolder: string;
+	selectManualFile: () => Promise<string | undefined>;
+}
+
+async function pickWorkspaceSignFile(
+	workspacePath: string,
+	options: WorkspaceSignFilePickerOptions
+): Promise<string | undefined> {
+	const discovery = await discoverSignFiles(
+		workspacePath,
+		options.patterns,
+		options.progressTitle,
+		options.searchContext
 	);
-
-	if (cancelled) {
-		return undefined;
-	}
-
-	if (certPaths.length === 0) {
-		return selectFile('Select signing certificate', {
-			'Certificates': ['pfx']
-		});
-	}
-
-	const items: vscode.QuickPickItem[] = certPaths.map((p) => {
-		const relDir = path.dirname(path.relative(workspacePath, p));
-		return {
-			label: path.basename(p),
-			description: relDir === '.' ? '' : relDir,
-			detail: p
-		};
+	return coordinateWorkspaceSignFileSelection(workspacePath, discovery, {
+		searchContext: options.searchContext,
+		placeHolder: options.placeHolder,
+		selectManualFile: options.selectManualFile,
+		showWarning: message => vscode.window.showWarningMessage(message, 'Browse…'),
+		showQuickPick: (items, quickPickOptions) => vscode.window.showQuickPick(items, quickPickOptions)
 	});
+}
 
-	items.push({ label: '$(folder-opened) Browse…', detail: 'Open a file picker' });
+async function discoverSignFiles(
+	workspacePath: string,
+	patterns: string[],
+	progressTitle: string,
+	searchContext: string
+): Promise<SignFileDiscovery> {
+	return discoverSignFilesWithFallback(
+		searchContext,
+		() => vscode.window.withProgress(
+			{ location: vscode.ProgressLocation.Notification, title: progressTitle, cancellable: true },
+			async (_progress, token) =>
+				runWithCancellation(token, signal =>
+					findWorkspaceArtifacts(
+						workspacePath,
+						createWorkspaceFileFinder(workspacePath),
+						patterns,
+						signal
+					)
+				)
+		),
+		message => vscode.window.showWarningMessage(message, 'Browse…')
+	);
+}
 
-	const picked = await vscode.window.showQuickPick(items, {
-		placeHolder: 'Select a signing certificate'
+function selectArtifactFile(): Promise<string | undefined> {
+	return selectFile('Select file to sign', {
+		...ARTIFACT_DIALOG_FILTER,
+		'Executables': ['exe', 'dll'],
+		'All files': ['*']
 	});
+}
 
-	if (!picked) {
-		return undefined;
-	}
+function selectCertificateFile(): Promise<string | undefined> {
+	return selectFile('Select signing certificate', {
+		'Certificates': ['pfx']
+	});
+}
 
-	if (picked.detail === 'Open a file picker') {
-		return selectFile('Select signing certificate', {
-			'Certificates': ['pfx']
-		});
-	}
-
-	return picked.detail;
+function createWorkspaceFileFinder(workspacePath: string): WorkspaceFileFinder {
+	return (includePattern, signal, maxResults) =>
+		runWithCancellationSource(
+			signal,
+			() => new vscode.CancellationTokenSource(),
+			async token => {
+				const matches = await vscode.workspace.findFiles(
+					new vscode.RelativePattern(workspacePath, includePattern),
+					null,
+					maxResults,
+					token
+				);
+				return matches.map(uri => uri.fsPath);
+			}
+		);
 }
 
 const FOLDER_PICKER_DETAIL = 'Open a folder picker';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,19 +20,7 @@ import {
 	isArtifactWithinRoot,
 	planPackCompletion
 } from './pack-result';
-import {
-	findWorkspaceArtifacts,
-	buildSignCommand,
-	CERTIFICATE_GLOBS,
-	executeSignFlow,
-	coordinateWorkspaceSignFileSelection,
-	discoverSignFilesWithFallback,
-	runWithCancellation,
-	runWithCancellationSource,
-	type SignFileDiscovery,
-	type SignFlowAdapter,
-	type WorkspaceFileFinder
-} from './sign-utils';
+import { findWorkspaceArtifacts, buildSignCommand, CERTIFICATE_GLOBS, executeSignFlow, type SignFlowAdapter } from './sign-utils';
 import { ARTIFACT_DIALOG_FILTER, ARTIFACT_GLOBS } from './artifact-types';
 import {
 	detectArchFromPath,
@@ -338,122 +326,117 @@ async function runWinappCapture(
 
 /**
  * Search the workspace for MSIX/APPX artifacts and let the user pick one via
- * a QuickPick. When no artifacts are found the function falls back to a native
- * file dialog; if the bounded workspace search produced only filtered results,
- * the handoff is surfaced explicitly first. A "Browse…" entry is always
- * appended so the user can opt into the dialog even when artifacts *are*
- * discovered.
+ * a QuickPick. When no artifacts are found the function falls back directly to
+ * a native file dialog; a "Browse…" entry is always appended so the user can
+ * opt into the dialog even when artifacts *are* discovered.
  *
  * @returns The selected file path, or `undefined` if cancelled.
  */
 async function pickSignableFile(workspacePath: string): Promise<string | undefined> {
-	return pickWorkspaceSignFile(workspacePath, {
-		patterns: ARTIFACT_GLOBS,
-		progressTitle: 'Searching for signable artifacts...',
-		searchContext: 'signable artifacts',
-		placeHolder: 'Select a package to sign',
-		selectManualFile: selectArtifactFile
+	let cancelled = false;
+	const artifactPaths = await vscode.window.withProgress(
+		{ location: vscode.ProgressLocation.Notification, title: 'Searching for signable artifacts...', cancellable: true },
+		async (_progress, token) => {
+			token.onCancellationRequested(() => { cancelled = true; });
+			return findWorkspaceArtifacts(workspacePath, ARTIFACT_GLOBS);
+		}
+	);
+
+	if (cancelled) {
+		return undefined;
+	}
+
+	if (artifactPaths.length === 0) {
+		return selectFile('Select file to sign', {
+			...ARTIFACT_DIALOG_FILTER,
+			'Executables': ['exe', 'dll'],
+			'All files': ['*']
+		});
+	}
+
+	const items: vscode.QuickPickItem[] = artifactPaths.map((p) => {
+		const relDir = path.dirname(path.relative(workspacePath, p));
+		return {
+			label: path.basename(p),
+			description: relDir === '.' ? '' : relDir,
+			detail: p
+		};
 	});
+
+	items.push({ label: '$(folder-opened) Browse…', detail: 'Open a file picker' });
+
+	const picked = await vscode.window.showQuickPick(items, {
+		placeHolder: 'Select a package to sign'
+	});
+
+	if (!picked) {
+		return undefined;
+	}
+
+	if (picked.detail === 'Open a file picker') {
+		return selectFile('Select file to sign', {
+			...ARTIFACT_DIALOG_FILTER,
+			'Executables': ['exe', 'dll'],
+			'All files': ['*']
+		});
+	}
+
+	return picked.detail;
 }
 
 /**
  * Search the workspace for PFX certificate files and let the user pick one
- * via a QuickPick. Falls back to a native file dialog when none are found; if
- * the bounded workspace search produced only filtered results, the handoff is
- * surfaced explicitly first. A "Browse…" entry is always appended.
+ * via a QuickPick. Falls back to a native file dialog when none are found;
+ * a "Browse…" entry is always appended.
  *
  * @returns The selected certificate path, or `undefined` if cancelled.
  */
 async function pickCertificateFile(workspacePath: string): Promise<string | undefined> {
-	return pickWorkspaceSignFile(workspacePath, {
-		patterns: CERTIFICATE_GLOBS,
-		progressTitle: 'Searching for certificates...',
-		searchContext: 'signing certificates',
-		placeHolder: 'Select a signing certificate',
-		selectManualFile: selectCertificateFile
-	});
-}
-
-interface WorkspaceSignFilePickerOptions {
-	patterns: string[];
-	progressTitle: string;
-	searchContext: string;
-	placeHolder: string;
-	selectManualFile: () => Promise<string | undefined>;
-}
-
-async function pickWorkspaceSignFile(
-	workspacePath: string,
-	options: WorkspaceSignFilePickerOptions
-): Promise<string | undefined> {
-	const discovery = await discoverSignFiles(
-		workspacePath,
-		options.patterns,
-		options.progressTitle,
-		options.searchContext
+	let cancelled = false;
+	const certPaths = await vscode.window.withProgress(
+		{ location: vscode.ProgressLocation.Notification, title: 'Searching for certificates...', cancellable: true },
+		async (_progress, token) => {
+			token.onCancellationRequested(() => { cancelled = true; });
+			return findWorkspaceArtifacts(workspacePath, CERTIFICATE_GLOBS);
+		}
 	);
-	return coordinateWorkspaceSignFileSelection(workspacePath, discovery, {
-		searchContext: options.searchContext,
-		placeHolder: options.placeHolder,
-		selectManualFile: options.selectManualFile,
-		showWarning: message => vscode.window.showWarningMessage(message, 'Browse…'),
-		showQuickPick: (items, quickPickOptions) => vscode.window.showQuickPick(items, quickPickOptions)
+
+	if (cancelled) {
+		return undefined;
+	}
+
+	if (certPaths.length === 0) {
+		return selectFile('Select signing certificate', {
+			'Certificates': ['pfx']
+		});
+	}
+
+	const items: vscode.QuickPickItem[] = certPaths.map((p) => {
+		const relDir = path.dirname(path.relative(workspacePath, p));
+		return {
+			label: path.basename(p),
+			description: relDir === '.' ? '' : relDir,
+			detail: p
+		};
 	});
-}
 
-async function discoverSignFiles(
-	workspacePath: string,
-	patterns: string[],
-	progressTitle: string,
-	searchContext: string
-): Promise<SignFileDiscovery> {
-	return discoverSignFilesWithFallback(
-		searchContext,
-		() => vscode.window.withProgress(
-			{ location: vscode.ProgressLocation.Notification, title: progressTitle, cancellable: true },
-			async (_progress, token) =>
-				runWithCancellation(token, signal =>
-					findWorkspaceArtifacts(
-						workspacePath,
-						createWorkspaceFileFinder(workspacePath),
-						patterns,
-						signal
-					)
-				)
-		),
-		message => vscode.window.showWarningMessage(message, 'Browse…')
-	);
-}
+	items.push({ label: '$(folder-opened) Browse…', detail: 'Open a file picker' });
 
-function selectArtifactFile(): Promise<string | undefined> {
-	return selectFile('Select file to sign', {
-		...ARTIFACT_DIALOG_FILTER,
-		'Executables': ['exe', 'dll'],
-		'All files': ['*']
+	const picked = await vscode.window.showQuickPick(items, {
+		placeHolder: 'Select a signing certificate'
 	});
-}
 
-function selectCertificateFile(): Promise<string | undefined> {
-	return selectFile('Select signing certificate', {
-		'Certificates': ['pfx']
-	});
-}
+	if (!picked) {
+		return undefined;
+	}
 
-function createWorkspaceFileFinder(workspacePath: string): WorkspaceFileFinder {
-	return (includePattern, signal, maxResults) =>
-		runWithCancellationSource(
-			signal,
-			() => new vscode.CancellationTokenSource(),
-			async token => {
-				const matches = await vscode.workspace.findFiles(
-					new vscode.RelativePattern(workspacePath, includePattern),
-					null,
-					maxResults,
-					token
-				);
-				return matches.map(uri => uri.fsPath);
-			}
-		);
+	if (picked.detail === 'Open a file picker') {
+		return selectFile('Select signing certificate', {
+			'Certificates': ['pfx']
+		});
+	}
+
+	return picked.detail;
 }
 
 const FOLDER_PICKER_DETAIL = 'Open a folder picker';

--- a/src/sign-utils.ts
+++ b/src/sign-utils.ts
@@ -1,12 +1,97 @@
 import * as fs from 'node:fs';
-import { glob } from 'glob';
+import * as path from 'node:path';
 import { escapePowerShellArg } from './winapp-cli-utils';
 import { ARTIFACT_GLOBS } from './artifact-types';
 
 /** Glob patterns for PFX certificate files within a workspace. */
 export const CERTIFICATE_GLOBS = ['**/*.pfx'];
 
-const SIGNABLE_ARTIFACT_IGNORES = ['**/node_modules/**', '**/.git/**'];
+const WORKSPACE_ARTIFACT_EXCLUDED_DIRECTORIES = new Set(['node_modules', '.git']);
+const STAT_BATCH_SIZE = 100;
+export const WORKSPACE_ARTIFACT_MAX_RESULTS = 500;
+export const WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT = 100;
+const WORKSPACE_ARTIFACT_DETECTION_LIMIT = WORKSPACE_ARTIFACT_MAX_RESULTS + 1;
+
+export type WorkspaceFileFinder = (
+	includePattern: string,
+	signal: AbortSignal | undefined,
+	maxResults: number
+) => Promise<string[]>;
+
+export interface CancellationTokenLike {
+	readonly isCancellationRequested: boolean;
+	onCancellationRequested(listener: () => void): { dispose(): void };
+}
+
+export interface CancellableResult<T> {
+	cancelled: boolean;
+	value: T | undefined;
+}
+
+export interface CancellationSourceLike<TToken> {
+	readonly token: TToken;
+	cancel(): void;
+	dispose(): void;
+}
+
+export interface WorkspaceArtifactDiscovery {
+	paths: string[];
+	/** The source search returned more than the 500 candidates inspected. */
+	sourceTruncated: boolean;
+	/** More than 100 valid candidates remained after post-filtering. */
+	displayTruncated: boolean;
+}
+
+export async function runWithCancellationSource<TToken, TResult>(
+	signal: AbortSignal | undefined,
+	createSource: () => CancellationSourceLike<TToken>,
+	operation: (token: TToken) => Promise<TResult>
+): Promise<TResult> {
+	const source = createSource();
+	const abort = () => source.cancel();
+	let listenerInstalled = false;
+	if (signal?.aborted) {
+		abort();
+	} else {
+		signal?.addEventListener('abort', abort, { once: true });
+		listenerInstalled = signal !== undefined;
+	}
+
+	try {
+		return await operation(source.token);
+	} finally {
+		if (listenerInstalled) {
+			signal?.removeEventListener('abort', abort);
+		}
+		source.dispose();
+	}
+}
+
+export async function runWithCancellation<T>(
+	token: CancellationTokenLike,
+	operation: (signal: AbortSignal) => Promise<T>
+): Promise<CancellableResult<T>> {
+	const abortController = new AbortController();
+	let cancelled = false;
+	const cancellation = token.onCancellationRequested(() => {
+		cancelled = true;
+		abortController.abort();
+	});
+
+	try {
+		if (token.isCancellationRequested) {
+			cancelled = true;
+			abortController.abort();
+		}
+		if (cancelled) {
+			return { cancelled: true, value: undefined };
+		}
+		const value = await operation(abortController.signal);
+		return { cancelled, value };
+	} finally {
+		cancellation.dispose();
+	}
+}
 
 /**
  * Build the CLI argument string for `winapp sign`.
@@ -21,37 +106,235 @@ export function buildSignCommand(filePath: string, certPath: string): string {
 /**
  * Find files matching the given glob patterns within a workspace root.
  *
- * Results are sorted by modification time (newest first) so the most recently
- * packaged artifact appears at the top of the QuickPick.
+ * Up to 500 source candidates are sorted by modification time (newest first).
+ * Truncation metadata distinguishes an incomplete source search from files
+ * omitted only from the QuickPick.
  */
 export async function findWorkspaceArtifacts(
 	workspacePath: string,
-	patterns: string[] = ARTIFACT_GLOBS
-): Promise<string[]> {
-	const results: string[] = [];
-	for (const pattern of patterns) {
-		const matches = await glob(pattern, {
-			cwd: workspacePath,
-			absolute: true,
-			nodir: true,
-			ignore: SIGNABLE_ARTIFACT_IGNORES
-		});
-		results.push(...matches);
+	findFiles: WorkspaceFileFinder,
+	patterns: string[] = ARTIFACT_GLOBS,
+	signal?: AbortSignal
+): Promise<WorkspaceArtifactDiscovery> {
+	if (signal?.aborted) {
+		return { paths: [], sourceTruncated: false, displayTruncated: false };
 	}
 
+	const includePattern = patterns.length === 1
+		? patterns[0]
+		: `{${patterns.join(',')}}`;
+
+	let results: string[];
+	try {
+		results = await findFiles(includePattern, signal, WORKSPACE_ARTIFACT_DETECTION_LIMIT);
+	} catch (error) {
+		if (signal?.aborted && isAbortError(error)) {
+			return { paths: [], sourceTruncated: false, displayTruncated: false };
+		}
+		throw error;
+	}
+
+	if (signal?.aborted) {
+		return { paths: [], sourceTruncated: false, displayTruncated: false };
+	}
+	const sourceTruncated = results.length > WORKSPACE_ARTIFACT_MAX_RESULTS;
+	results = results.slice(0, WORKSPACE_ARTIFACT_MAX_RESULTS);
+	results = results.filter(filePath => !isExcludedWorkspacePath(workspacePath, filePath));
+	const displayTruncated = results.length > WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT;
+
 	// Sort by mtime descending (newest first); if stat fails, push to end.
-	const withStats = await Promise.all(
-		results.map(async (p) => {
-			try {
-				const stat = await fs.promises.stat(p);
-				return { path: p, mtime: stat.mtimeMs };
-			} catch {
-				return { path: p, mtime: 0 };
-			}
-		})
-	);
+	const withStats: Array<{ path: string; mtime: number }> = [];
+	for (let index = 0; index < results.length; index += STAT_BATCH_SIZE) {
+		if (signal?.aborted) {
+			return { paths: [], sourceTruncated: false, displayTruncated: false };
+		}
+		const batch = await Promise.all(
+			results.slice(index, index + STAT_BATCH_SIZE).map(async (p) => {
+				try {
+					const stat = await fs.promises.stat(p);
+					return { path: p, mtime: stat.mtimeMs };
+				} catch {
+					return { path: p, mtime: 0 };
+				}
+			})
+		);
+		withStats.push(...batch);
+	}
+	if (signal?.aborted) {
+		return { paths: [], sourceTruncated: false, displayTruncated: false };
+	}
 	withStats.sort((a, b) => b.mtime - a.mtime);
-	return withStats.map((s) => s.path);
+	return {
+		paths: withStats
+			.slice(0, WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT)
+			.map((s) => s.path),
+		sourceTruncated,
+		displayTruncated
+	};
+}
+
+function isAbortError(error: unknown): boolean {
+	if (typeof error !== 'object' || error === null || !('name' in error)) {
+		return false;
+	}
+	const name = (error as { name?: unknown }).name;
+	return name === 'AbortError' || name === 'Canceled' || name === 'CancellationError';
+}
+
+function isExcludedWorkspacePath(workspacePath: string, filePath: string): boolean {
+	const relativePath = path.relative(workspacePath, filePath);
+	return relativePath.split(path.sep).some(segment => {
+		const comparableSegment = process.platform === 'win32' ? segment.toLowerCase() : segment;
+		return WORKSPACE_ARTIFACT_EXCLUDED_DIRECTORIES.has(comparableSegment);
+	});
+}
+
+export interface SignFileDiscovery {
+	cancelled: boolean;
+	result?: WorkspaceArtifactDiscovery;
+	browseRequested?: boolean;
+}
+
+export interface EmptySignFileDiscoveryWarningOptions {
+	searchContext: string;
+	showWarning: (message: string) => PromiseLike<string | undefined>;
+}
+
+export async function discoverSignFilesWithFallback(
+	searchContext: string,
+	discover: () => PromiseLike<CancellableResult<WorkspaceArtifactDiscovery>>,
+	showWarning: (message: string) => PromiseLike<string | undefined>
+): Promise<SignFileDiscovery> {
+	try {
+		const discovery = await discover();
+		return { cancelled: discovery.cancelled, result: discovery.value };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const choice = await showWarning(
+			`Could not search the workspace for ${searchContext}: ${message}. You can select a file manually.`
+		);
+		return { cancelled: false, browseRequested: choice === 'Browse…' };
+	}
+}
+
+export async function handoffSignFileDiscovery(
+	discovery: SignFileDiscovery,
+	selectManualFile: () => PromiseLike<string | undefined>,
+	emptyDiscoveryWarning?: EmptySignFileDiscoveryWarningOptions
+): Promise<WorkspaceArtifactDiscovery | string | undefined> {
+	if (discovery.browseRequested) {
+		return selectManualFile();
+	}
+	if (discovery.cancelled || !discovery.result) {
+		return undefined;
+	}
+	if (discovery.result.paths.length === 0) {
+		if (discovery.result.sourceTruncated && emptyDiscoveryWarning) {
+			const choice = await emptyDiscoveryWarning.showWarning(
+				`Could only inspect the first ${WORKSPACE_ARTIFACT_MAX_RESULTS} workspace matches for ${emptyDiscoveryWarning.searchContext}, and none of the inspected matches can be shown here. Additional matching files may still exist. You can select a file manually.`
+			);
+			if (choice !== 'Browse…') {
+				return undefined;
+			}
+		}
+		return selectManualFile();
+	}
+	return discovery.result;
+}
+
+export interface SignWorkspaceQuickPickItem {
+	label: string;
+	description?: string;
+	detail: string;
+}
+
+export function createWorkspaceSignFileQuickPickItem(
+	workspacePath: string,
+	filePath: string
+): SignWorkspaceQuickPickItem {
+	const relDir = path.dirname(path.relative(workspacePath, filePath));
+	return {
+		label: path.basename(filePath),
+		description: relDir === '.' ? '' : relDir,
+		detail: filePath
+	};
+}
+
+export interface CoordinateWorkspaceSignFileSelectionOptions {
+	searchContext: string;
+	placeHolder: string;
+	selectManualFile: () => PromiseLike<string | undefined>;
+	showWarning: (message: string) => PromiseLike<string | undefined>;
+	showQuickPick: (
+		items: readonly SignWorkspaceQuickPickItem[],
+		options: { placeHolder: string }
+	) => PromiseLike<SignWorkspaceQuickPickItem | undefined>;
+}
+
+export async function coordinateWorkspaceSignFileSelection(
+	workspacePath: string,
+	discovery: SignFileDiscovery,
+	options: CoordinateWorkspaceSignFileSelectionOptions
+): Promise<string | undefined> {
+	const handoff = await handoffSignFileDiscovery(
+		discovery,
+		options.selectManualFile,
+		{
+			searchContext: options.searchContext,
+			showWarning: options.showWarning
+		}
+	);
+	if (typeof handoff === 'string' || handoff === undefined) {
+		return handoff;
+	}
+
+	const items: SignWorkspaceQuickPickItem[] = handoff.paths.map(filePath =>
+		createWorkspaceSignFileQuickPickItem(workspacePath, filePath)
+	);
+	const browseItem = createSignBrowseItem(handoff);
+	items.push(browseItem);
+
+	const picked = await options.showQuickPick(items, {
+		placeHolder: options.placeHolder
+	});
+	if (!picked) {
+		return undefined;
+	}
+	if (
+		picked === browseItem ||
+		(
+			picked.label === browseItem.label &&
+			picked.description === browseItem.description &&
+			picked.detail === browseItem.detail
+		)
+	) {
+		return options.selectManualFile();
+	}
+	return picked.detail;
+}
+
+export function createSignBrowseItem(
+	discovery: Pick<WorkspaceArtifactDiscovery, 'sourceTruncated' | 'displayTruncated'>
+): SignWorkspaceQuickPickItem {
+	if (discovery.sourceTruncated && discovery.displayTruncated) {
+		return {
+			label: '$(folder-opened) Browse… (more files available)',
+			detail: 'Showing newest 100 of the first 500 workspace matches. Browse to choose a different file manually because additional workspace matches may exist'
+		};
+	}
+	if (discovery.displayTruncated) {
+		return {
+			label: '$(folder-opened) Browse… (more files available)',
+			detail: 'Showing newest 100 matching files. Browse to choose a different file manually'
+		};
+	}
+	if (discovery.sourceTruncated) {
+		return {
+			label: '$(folder-opened) Browse… (additional files may exist)',
+			detail: 'Only the first 500 workspace matches were checked. Browse to choose a different file manually because additional matches may exist'
+		};
+	}
+	return { label: '$(folder-opened) Browse…', detail: 'Open a file picker' };
 }
 
 // ──────────────────────────────────────────────────────

--- a/src/sign-utils.ts
+++ b/src/sign-utils.ts
@@ -1,12 +1,17 @@
 import * as fs from 'node:fs';
-import { glob } from 'glob';
+import * as path from 'node:path';
 import { escapePowerShellArg } from './winapp-cli-utils';
 import { ARTIFACT_GLOBS } from './artifact-types';
 
 /** Glob patterns for PFX certificate files within a workspace. */
 export const CERTIFICATE_GLOBS = ['**/*.pfx'];
 
-const SIGNABLE_ARTIFACT_IGNORES = ['**/node_modules/**', '**/.git/**'];
+const SIGNABLE_ARTIFACT_IGNORES = new Set(['node_modules', '.git']);
+
+export type WorkspaceFileFinder = (
+	includePattern: string,
+	signal?: AbortSignal
+) => Promise<string[]>;
 
 /**
  * Build the CLI argument string for `winapp sign`.
@@ -26,32 +31,60 @@ export function buildSignCommand(filePath: string, certPath: string): string {
  */
 export async function findWorkspaceArtifacts(
 	workspacePath: string,
-	patterns: string[] = ARTIFACT_GLOBS
+	findFiles: WorkspaceFileFinder,
+	patterns: string[] = ARTIFACT_GLOBS,
+	signal?: AbortSignal
 ): Promise<string[]> {
-	const results: string[] = [];
-	for (const pattern of patterns) {
-		const matches = await glob(pattern, {
-			cwd: workspacePath,
-			absolute: true,
-			nodir: true,
-			ignore: SIGNABLE_ARTIFACT_IGNORES
-		});
-		results.push(...matches);
+	if (signal?.aborted) {
+		return [];
+	}
+
+	const includePattern = patterns.length === 1 ? patterns[0] : `{${patterns.join(',')}}`;
+	let results: string[];
+	try {
+		results = await findFiles(includePattern, signal);
+	} catch (error) {
+		if (signal?.aborted && isCancellationError(error)) {
+			return [];
+		}
+		throw error;
 	}
 
 	// Sort by mtime descending (newest first); if stat fails, push to end.
-	const withStats = await Promise.all(
-		results.map(async (p) => {
-			try {
-				const stat = await fs.promises.stat(p);
-				return { path: p, mtime: stat.mtimeMs };
-			} catch {
-				return { path: p, mtime: 0 };
-			}
-		})
-	);
+	const withStats: Array<{ path: string; mtime: number }> = [];
+	for (const filePath of results) {
+		if (signal?.aborted) {
+			return [];
+		}
+		if (isIgnoredWorkspacePath(workspacePath, filePath)) {
+			continue;
+		}
+		try {
+			const stat = await fs.promises.stat(filePath);
+			withStats.push({ path: filePath, mtime: stat.mtimeMs });
+		} catch {
+			withStats.push({ path: filePath, mtime: 0 });
+		}
+	}
+
 	withStats.sort((a, b) => b.mtime - a.mtime);
 	return withStats.map((s) => s.path);
+}
+
+function isIgnoredWorkspacePath(workspacePath: string, filePath: string): boolean {
+	return path.relative(workspacePath, filePath)
+		.split(path.sep)
+		.some(segment => SIGNABLE_ARTIFACT_IGNORES.has(
+			process.platform === 'win32' ? segment.toLowerCase() : segment
+		));
+}
+
+function isCancellationError(error: unknown): boolean {
+	if (typeof error !== 'object' || error === null || !('name' in error)) {
+		return false;
+	}
+	const name = (error as { name?: unknown }).name;
+	return name === 'AbortError' || name === 'Canceled' || name === 'CancellationError';
 }
 
 // ──────────────────────────────────────────────────────

--- a/src/sign-utils.ts
+++ b/src/sign-utils.ts
@@ -1,97 +1,12 @@
 import * as fs from 'node:fs';
-import * as path from 'node:path';
+import { glob } from 'glob';
 import { escapePowerShellArg } from './winapp-cli-utils';
 import { ARTIFACT_GLOBS } from './artifact-types';
 
 /** Glob patterns for PFX certificate files within a workspace. */
 export const CERTIFICATE_GLOBS = ['**/*.pfx'];
 
-const WORKSPACE_ARTIFACT_EXCLUDED_DIRECTORIES = new Set(['node_modules', '.git']);
-const STAT_BATCH_SIZE = 100;
-export const WORKSPACE_ARTIFACT_MAX_RESULTS = 500;
-export const WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT = 100;
-const WORKSPACE_ARTIFACT_DETECTION_LIMIT = WORKSPACE_ARTIFACT_MAX_RESULTS + 1;
-
-export type WorkspaceFileFinder = (
-	includePattern: string,
-	signal: AbortSignal | undefined,
-	maxResults: number
-) => Promise<string[]>;
-
-export interface CancellationTokenLike {
-	readonly isCancellationRequested: boolean;
-	onCancellationRequested(listener: () => void): { dispose(): void };
-}
-
-export interface CancellableResult<T> {
-	cancelled: boolean;
-	value: T | undefined;
-}
-
-export interface CancellationSourceLike<TToken> {
-	readonly token: TToken;
-	cancel(): void;
-	dispose(): void;
-}
-
-export interface WorkspaceArtifactDiscovery {
-	paths: string[];
-	/** The source search returned more than the 500 candidates inspected. */
-	sourceTruncated: boolean;
-	/** More than 100 valid candidates remained after post-filtering. */
-	displayTruncated: boolean;
-}
-
-export async function runWithCancellationSource<TToken, TResult>(
-	signal: AbortSignal | undefined,
-	createSource: () => CancellationSourceLike<TToken>,
-	operation: (token: TToken) => Promise<TResult>
-): Promise<TResult> {
-	const source = createSource();
-	const abort = () => source.cancel();
-	let listenerInstalled = false;
-	if (signal?.aborted) {
-		abort();
-	} else {
-		signal?.addEventListener('abort', abort, { once: true });
-		listenerInstalled = signal !== undefined;
-	}
-
-	try {
-		return await operation(source.token);
-	} finally {
-		if (listenerInstalled) {
-			signal?.removeEventListener('abort', abort);
-		}
-		source.dispose();
-	}
-}
-
-export async function runWithCancellation<T>(
-	token: CancellationTokenLike,
-	operation: (signal: AbortSignal) => Promise<T>
-): Promise<CancellableResult<T>> {
-	const abortController = new AbortController();
-	let cancelled = false;
-	const cancellation = token.onCancellationRequested(() => {
-		cancelled = true;
-		abortController.abort();
-	});
-
-	try {
-		if (token.isCancellationRequested) {
-			cancelled = true;
-			abortController.abort();
-		}
-		if (cancelled) {
-			return { cancelled: true, value: undefined };
-		}
-		const value = await operation(abortController.signal);
-		return { cancelled, value };
-	} finally {
-		cancellation.dispose();
-	}
-}
+const SIGNABLE_ARTIFACT_IGNORES = ['**/node_modules/**', '**/.git/**'];
 
 /**
  * Build the CLI argument string for `winapp sign`.
@@ -106,235 +21,37 @@ export function buildSignCommand(filePath: string, certPath: string): string {
 /**
  * Find files matching the given glob patterns within a workspace root.
  *
- * Up to 500 source candidates are sorted by modification time (newest first).
- * Truncation metadata distinguishes an incomplete source search from files
- * omitted only from the QuickPick.
+ * Results are sorted by modification time (newest first) so the most recently
+ * packaged artifact appears at the top of the QuickPick.
  */
 export async function findWorkspaceArtifacts(
 	workspacePath: string,
-	findFiles: WorkspaceFileFinder,
-	patterns: string[] = ARTIFACT_GLOBS,
-	signal?: AbortSignal
-): Promise<WorkspaceArtifactDiscovery> {
-	if (signal?.aborted) {
-		return { paths: [], sourceTruncated: false, displayTruncated: false };
+	patterns: string[] = ARTIFACT_GLOBS
+): Promise<string[]> {
+	const results: string[] = [];
+	for (const pattern of patterns) {
+		const matches = await glob(pattern, {
+			cwd: workspacePath,
+			absolute: true,
+			nodir: true,
+			ignore: SIGNABLE_ARTIFACT_IGNORES
+		});
+		results.push(...matches);
 	}
-
-	const includePattern = patterns.length === 1
-		? patterns[0]
-		: `{${patterns.join(',')}}`;
-
-	let results: string[];
-	try {
-		results = await findFiles(includePattern, signal, WORKSPACE_ARTIFACT_DETECTION_LIMIT);
-	} catch (error) {
-		if (signal?.aborted && isAbortError(error)) {
-			return { paths: [], sourceTruncated: false, displayTruncated: false };
-		}
-		throw error;
-	}
-
-	if (signal?.aborted) {
-		return { paths: [], sourceTruncated: false, displayTruncated: false };
-	}
-	const sourceTruncated = results.length > WORKSPACE_ARTIFACT_MAX_RESULTS;
-	results = results.slice(0, WORKSPACE_ARTIFACT_MAX_RESULTS);
-	results = results.filter(filePath => !isExcludedWorkspacePath(workspacePath, filePath));
-	const displayTruncated = results.length > WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT;
 
 	// Sort by mtime descending (newest first); if stat fails, push to end.
-	const withStats: Array<{ path: string; mtime: number }> = [];
-	for (let index = 0; index < results.length; index += STAT_BATCH_SIZE) {
-		if (signal?.aborted) {
-			return { paths: [], sourceTruncated: false, displayTruncated: false };
-		}
-		const batch = await Promise.all(
-			results.slice(index, index + STAT_BATCH_SIZE).map(async (p) => {
-				try {
-					const stat = await fs.promises.stat(p);
-					return { path: p, mtime: stat.mtimeMs };
-				} catch {
-					return { path: p, mtime: 0 };
-				}
-			})
-		);
-		withStats.push(...batch);
-	}
-	if (signal?.aborted) {
-		return { paths: [], sourceTruncated: false, displayTruncated: false };
-	}
-	withStats.sort((a, b) => b.mtime - a.mtime);
-	return {
-		paths: withStats
-			.slice(0, WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT)
-			.map((s) => s.path),
-		sourceTruncated,
-		displayTruncated
-	};
-}
-
-function isAbortError(error: unknown): boolean {
-	if (typeof error !== 'object' || error === null || !('name' in error)) {
-		return false;
-	}
-	const name = (error as { name?: unknown }).name;
-	return name === 'AbortError' || name === 'Canceled' || name === 'CancellationError';
-}
-
-function isExcludedWorkspacePath(workspacePath: string, filePath: string): boolean {
-	const relativePath = path.relative(workspacePath, filePath);
-	return relativePath.split(path.sep).some(segment => {
-		const comparableSegment = process.platform === 'win32' ? segment.toLowerCase() : segment;
-		return WORKSPACE_ARTIFACT_EXCLUDED_DIRECTORIES.has(comparableSegment);
-	});
-}
-
-export interface SignFileDiscovery {
-	cancelled: boolean;
-	result?: WorkspaceArtifactDiscovery;
-	browseRequested?: boolean;
-}
-
-export interface EmptySignFileDiscoveryWarningOptions {
-	searchContext: string;
-	showWarning: (message: string) => PromiseLike<string | undefined>;
-}
-
-export async function discoverSignFilesWithFallback(
-	searchContext: string,
-	discover: () => PromiseLike<CancellableResult<WorkspaceArtifactDiscovery>>,
-	showWarning: (message: string) => PromiseLike<string | undefined>
-): Promise<SignFileDiscovery> {
-	try {
-		const discovery = await discover();
-		return { cancelled: discovery.cancelled, result: discovery.value };
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		const choice = await showWarning(
-			`Could not search the workspace for ${searchContext}: ${message}. You can select a file manually.`
-		);
-		return { cancelled: false, browseRequested: choice === 'Browse…' };
-	}
-}
-
-export async function handoffSignFileDiscovery(
-	discovery: SignFileDiscovery,
-	selectManualFile: () => PromiseLike<string | undefined>,
-	emptyDiscoveryWarning?: EmptySignFileDiscoveryWarningOptions
-): Promise<WorkspaceArtifactDiscovery | string | undefined> {
-	if (discovery.browseRequested) {
-		return selectManualFile();
-	}
-	if (discovery.cancelled || !discovery.result) {
-		return undefined;
-	}
-	if (discovery.result.paths.length === 0) {
-		if (discovery.result.sourceTruncated && emptyDiscoveryWarning) {
-			const choice = await emptyDiscoveryWarning.showWarning(
-				`Could only inspect the first ${WORKSPACE_ARTIFACT_MAX_RESULTS} workspace matches for ${emptyDiscoveryWarning.searchContext}, and none of the inspected matches can be shown here. Additional matching files may still exist. You can select a file manually.`
-			);
-			if (choice !== 'Browse…') {
-				return undefined;
+	const withStats = await Promise.all(
+		results.map(async (p) => {
+			try {
+				const stat = await fs.promises.stat(p);
+				return { path: p, mtime: stat.mtimeMs };
+			} catch {
+				return { path: p, mtime: 0 };
 			}
-		}
-		return selectManualFile();
-	}
-	return discovery.result;
-}
-
-export interface SignWorkspaceQuickPickItem {
-	label: string;
-	description?: string;
-	detail: string;
-}
-
-export function createWorkspaceSignFileQuickPickItem(
-	workspacePath: string,
-	filePath: string
-): SignWorkspaceQuickPickItem {
-	const relDir = path.dirname(path.relative(workspacePath, filePath));
-	return {
-		label: path.basename(filePath),
-		description: relDir === '.' ? '' : relDir,
-		detail: filePath
-	};
-}
-
-export interface CoordinateWorkspaceSignFileSelectionOptions {
-	searchContext: string;
-	placeHolder: string;
-	selectManualFile: () => PromiseLike<string | undefined>;
-	showWarning: (message: string) => PromiseLike<string | undefined>;
-	showQuickPick: (
-		items: readonly SignWorkspaceQuickPickItem[],
-		options: { placeHolder: string }
-	) => PromiseLike<SignWorkspaceQuickPickItem | undefined>;
-}
-
-export async function coordinateWorkspaceSignFileSelection(
-	workspacePath: string,
-	discovery: SignFileDiscovery,
-	options: CoordinateWorkspaceSignFileSelectionOptions
-): Promise<string | undefined> {
-	const handoff = await handoffSignFileDiscovery(
-		discovery,
-		options.selectManualFile,
-		{
-			searchContext: options.searchContext,
-			showWarning: options.showWarning
-		}
+		})
 	);
-	if (typeof handoff === 'string' || handoff === undefined) {
-		return handoff;
-	}
-
-	const items: SignWorkspaceQuickPickItem[] = handoff.paths.map(filePath =>
-		createWorkspaceSignFileQuickPickItem(workspacePath, filePath)
-	);
-	const browseItem = createSignBrowseItem(handoff);
-	items.push(browseItem);
-
-	const picked = await options.showQuickPick(items, {
-		placeHolder: options.placeHolder
-	});
-	if (!picked) {
-		return undefined;
-	}
-	if (
-		picked === browseItem ||
-		(
-			picked.label === browseItem.label &&
-			picked.description === browseItem.description &&
-			picked.detail === browseItem.detail
-		)
-	) {
-		return options.selectManualFile();
-	}
-	return picked.detail;
-}
-
-export function createSignBrowseItem(
-	discovery: Pick<WorkspaceArtifactDiscovery, 'sourceTruncated' | 'displayTruncated'>
-): SignWorkspaceQuickPickItem {
-	if (discovery.sourceTruncated && discovery.displayTruncated) {
-		return {
-			label: '$(folder-opened) Browse… (more files available)',
-			detail: 'Showing newest 100 of the first 500 workspace matches. Browse to choose a different file manually because additional workspace matches may exist'
-		};
-	}
-	if (discovery.displayTruncated) {
-		return {
-			label: '$(folder-opened) Browse… (more files available)',
-			detail: 'Showing newest 100 matching files. Browse to choose a different file manually'
-		};
-	}
-	if (discovery.sourceTruncated) {
-		return {
-			label: '$(folder-opened) Browse… (additional files may exist)',
-			detail: 'Only the first 500 workspace matches were checked. Browse to choose a different file manually because additional matches may exist'
-		};
-	}
-	return { label: '$(folder-opened) Browse…', detail: 'Open a file picker' };
+	withStats.sort((a, b) => b.mtime - a.mtime);
+	return withStats.map((s) => s.path);
 }
 
 // ──────────────────────────────────────────────────────

--- a/src/test/e2e/README.md
+++ b/src/test/e2e/README.md
@@ -44,20 +44,17 @@ Tests run against real AppxManifest files stored in `src/test/fixtures/`:
 
 ---
 
-## Test inventory
+## Test inventory (127 tests)
 
-### `sign-quickpick.spec.ts` — 6 tests
+### `sign-quickpick.spec.ts` — 3 tests (2 active, 1 skipped)
 
 Validates that `winapp.sign` discovers workspace MSIX artifacts and certificates, presenting them in QuickPicks.
 
 | # | Test | Validates |
 |---|------|-----------|
 | 1 | shows QuickPick with .msix file and Browse option when artifacts exist | QuickPick appears with artifact rows and Browse… fallback |
-| 2 | keeps build artifacts visible while excluding dependency and repository metadata | `files.exclude` does not hide build artifacts; `node_modules` and `.git` matches remain hidden |
-| 3 | shows certificate QuickPick with .pfx file after selecting a package | Certificate QuickPick appears after package selection with .pfx rows and Browse… fallback |
-| 4 | cancelling the artifact QuickPick aborts the sign flow | Artifact selection can be cancelled without opening a terminal |
-| 5 | selecting Browse dismisses the QuickPick in a native-dialog smoke test | Browse transitions from the QuickPick to the native file dialog |
-| 6 | cancelling the certificate QuickPick aborts the sign flow | Certificate selection can be cancelled without opening a terminal |
+| 2 | shows certificate QuickPick with .pfx file after selecting a package | Certificate QuickPick appears after package selection with .pfx rows and Browse… fallback |
+| 3 | *(skipped)* skips package QuickPick when invoked with prefilled path | Needs VS Code extension test host — see [#83](https://github.com/microsoft/WinAppVSCE/issues/83) |
 
 ### `editor-launch.spec.ts` — 11 tests
 

--- a/src/test/e2e/README.md
+++ b/src/test/e2e/README.md
@@ -44,17 +44,20 @@ Tests run against real AppxManifest files stored in `src/test/fixtures/`:
 
 ---
 
-## Test inventory (127 tests)
+## Test inventory
 
-### `sign-quickpick.spec.ts` — 3 tests (2 active, 1 skipped)
+### `sign-quickpick.spec.ts` — 6 tests
 
 Validates that `winapp.sign` discovers workspace MSIX artifacts and certificates, presenting them in QuickPicks.
 
 | # | Test | Validates |
 |---|------|-----------|
 | 1 | shows QuickPick with .msix file and Browse option when artifacts exist | QuickPick appears with artifact rows and Browse… fallback |
-| 2 | shows certificate QuickPick with .pfx file after selecting a package | Certificate QuickPick appears after package selection with .pfx rows and Browse… fallback |
-| 3 | *(skipped)* skips package QuickPick when invoked with prefilled path | Needs VS Code extension test host — see [#83](https://github.com/microsoft/WinAppVSCE/issues/83) |
+| 2 | keeps build artifacts visible while excluding dependency and repository metadata | `files.exclude` does not hide build artifacts; `node_modules` and `.git` matches remain hidden |
+| 3 | shows certificate QuickPick with .pfx file after selecting a package | Certificate QuickPick appears after package selection with .pfx rows and Browse… fallback |
+| 4 | cancelling the artifact QuickPick aborts the sign flow | Artifact selection can be cancelled without opening a terminal |
+| 5 | selecting Browse dismisses the QuickPick in a native-dialog smoke test | Browse transitions from the QuickPick to the native file dialog |
+| 6 | cancelling the certificate QuickPick aborts the sign flow | Certificate selection can be cancelled without opening a terminal |
 
 ### `editor-launch.spec.ts` — 11 tests
 

--- a/src/test/e2e/sign-quickpick.spec.ts
+++ b/src/test/e2e/sign-quickpick.spec.ts
@@ -5,24 +5,20 @@
  *   Opens VS Code in a workspace containing a .msix file, runs "WinApp: Sign Package",
  *   and asserts that a QuickPick appears listing the artifact and a "Browse…" option.
  *
- * Test 2 — Discovery exclusions:
- *   Verifies user `files.exclude` settings do not hide build artifacts while
- *   `node_modules` and `.git` remain excluded from the QuickPick.
- *
- * Test 3 — Certificate QuickPick:
+ * Test 2 — Certificate QuickPick:
  *   Opens VS Code in a workspace containing both a .msix and a .pfx file, selects
  *   the package, and asserts that a second QuickPick appears for certificate selection.
  *
- * Test 4 — Cancel artifact QuickPick:
+ * Test 3 — Cancel artifact QuickPick:
  *   Opens VS Code, runs "WinApp: Sign Package", and presses Escape to dismiss the
  *   artifact QuickPick. Verifies the sign flow aborts gracefully (no certificate
  *   picker or terminal appears).
  *
- * Test 5 — Browse option:
+ * Test 4 — Browse option:
  *   Opens VS Code, runs "WinApp: Sign Package", selects "Browse…" from the QuickPick,
  *   and verifies that a native file dialog opens (the Open dialog title bar appears).
  *
- * Test 6 — Cancel certificate QuickPick:
+ * Test 5 — Cancel certificate QuickPick:
  *   Opens VS Code, selects an artifact from the package QuickPick, then presses
  *   Escape on the certificate QuickPick. Verifies the sign flow aborts (no terminal).
  */
@@ -96,16 +92,6 @@ function createSignTestWorkspace(options?: { includePfx?: boolean }): string {
     return tmpDir;
 }
 
-function configureFilesExclude(workspacePath: string): void {
-    const settingsPath = path.join(workspacePath, '.vscode', 'settings.json');
-    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
-    fs.writeFileSync(settingsPath, JSON.stringify({
-        'files.exclude': {
-            '**/AppPackages': true
-        }
-    }));
-}
-
 // ──────────────────────────────────────────────────────
 // Test 1 — Workspace with .msix artifact
 // ──────────────────────────────────────────────────────
@@ -123,9 +109,20 @@ test.describe('winapp.sign command — artifact discovery', () => {
             // Run "WinApp: Sign Package"
             await runCommandPalette(page, 'WinApp: Sign Package');
 
+            // The QuickPick should appear. Wait for the quick-input widget to
+            // become visible. VS Code keeps the widget in the DOM with
+            // style="display:none" when inactive, so we must also exclude that.
             const quickInput = page.locator('.quick-input-widget');
+            // Wait for either the quick-input list rows or the placeholder to
+            // appear — this accounts for VS Code toggling visibility classes.
+            await expect(
+                quickInput.locator('.quick-input-list .monaco-list-row').first()
+            ).toBeVisible({ timeout: 20_000 });
+
+            // The placeholder text should mention signing
             const inputBox = quickInput.locator('.quick-input-filter input[type="text"]');
-            await expect(inputBox).toHaveAttribute('placeholder', /package to sign/, { timeout: 20_000 });
+            const placeholder = await inputBox.getAttribute('placeholder');
+            expect(placeholder).toContain('package to sign');
 
             // There should be at least 2 items: the .msix file + Browse…
             const items = quickInput.locator('.quick-input-list .monaco-list-row');
@@ -152,43 +149,6 @@ test.describe('winapp.sign command — artifact discovery', () => {
         }
     });
 
-    test('keeps build artifacts visible while excluding dependency and repository metadata', async () => {
-        const tmpDir = createSignTestWorkspace();
-        configureFilesExclude(tmpDir);
-        fs.mkdirSync(path.join(tmpDir, 'node_modules', 'pkg'), { recursive: true });
-        fs.writeFileSync(path.join(tmpDir, 'node_modules', 'pkg', 'Ignored.msix'), Buffer.alloc(128));
-        fs.mkdirSync(path.join(tmpDir, 'vendor', '.git', 'objects'), { recursive: true });
-        fs.writeFileSync(path.join(tmpDir, 'vendor', '.git', 'objects', 'Ignored.appx'), Buffer.alloc(128));
-
-        let app: ElectronApplication | undefined;
-        try {
-            const launched = await launchVSCodeForFolder(tmpDir);
-            app = launched.app;
-            const page = launched.page;
-
-            await runCommandPalette(page, 'WinApp: Sign Package');
-
-            const quickInput = page.locator('.quick-input-widget');
-            const inputBox = quickInput.locator('.quick-input-filter input[type="text"]');
-            await expect(inputBox).toHaveAttribute('placeholder', /package to sign/, { timeout: 20_000 });
-            const items = quickInput.locator('.quick-input-list .monaco-list-row');
-            await expect(items.first()).toBeVisible({ timeout: 20_000 });
-            await expect(items).toHaveCount(2, { timeout: 10_000 });
-
-            const quickPickText = await items.allTextContents();
-            expect(quickPickText.join(' ')).toContain('MyApp_1.0.0.0_x64.msix');
-            expect(quickPickText.join(' ')).not.toContain('Ignored.msix');
-            expect(quickPickText.join(' ')).not.toContain('Ignored.appx');
-
-            await page.keyboard.press('Escape');
-        } finally {
-            if (app) {
-                await app.close().catch(() => {});
-            }
-            fs.rmSync(tmpDir, { recursive: true, force: true });
-        }
-    });
-
     test('shows certificate QuickPick with .pfx file after selecting a package', async () => {
         const tmpDir = createSignTestWorkspace({ includePfx: true });
 
@@ -201,18 +161,29 @@ test.describe('winapp.sign command — artifact discovery', () => {
             // Run "WinApp: Sign Package"
             await runCommandPalette(page, 'WinApp: Sign Package');
 
+            // Wait for the artifact QuickPick to appear
             const quickInput = page.locator('.quick-input-widget');
+            await expect(
+                quickInput.locator('.quick-input-list .monaco-list-row').first()
+            ).toBeVisible({ timeout: 20_000 });
+
+            // Verify it's the package picker
             const packageInput = quickInput.locator('.quick-input-filter input[type="text"]');
-            await expect(packageInput).toHaveAttribute('placeholder', /package to sign/, { timeout: 20_000 });
+            const packagePlaceholder = await packageInput.getAttribute('placeholder');
+            expect(packagePlaceholder).toContain('package to sign');
 
-            // Select the artifact by label so a stale Command Palette row cannot win the race.
-            const packageItem = quickInput.locator('.quick-input-list .monaco-list-row')
-                .filter({ hasText: 'MyApp_1.0.0.0_x64.msix' });
-            await expect(packageItem).toHaveCount(1, { timeout: 10_000 });
-            await packageItem.click();
+            // Select the .msix artifact (first item) to advance to cert picker
+            await quickInput.locator('.quick-input-list .monaco-list-row').first().click();
 
+            // Wait for the certificate QuickPick to appear (second picker)
+            await expect(
+                quickInput.locator('.quick-input-list .monaco-list-row').first()
+            ).toBeVisible({ timeout: 20_000 });
+
+            // The placeholder should now mention certificate
             const certInput = quickInput.locator('.quick-input-filter input[type="text"]');
-            await expect(certInput).toHaveAttribute('placeholder', /signing certificate/, { timeout: 20_000 });
+            const certPlaceholder = await certInput.getAttribute('placeholder');
+            expect(certPlaceholder).toContain('signing certificate');
 
             // There should be 2 items: the .pfx file + Browse…
             const certItems = quickInput.locator('.quick-input-list .monaco-list-row');
@@ -254,17 +225,26 @@ test.describe('winapp.sign command — artifact discovery', () => {
             // Run "WinApp: Sign Package"
             await runCommandPalette(page, 'WinApp: Sign Package');
 
+            // Wait for the artifact QuickPick to appear
             const quickInput = page.locator('.quick-input-widget');
+            await expect(
+                quickInput.locator('.quick-input-list .monaco-list-row').first()
+            ).toBeVisible({ timeout: 20_000 });
+
+            // Verify it's the package picker
             const inputBox = quickInput.locator('.quick-input-filter input[type="text"]');
-            await expect(inputBox).toHaveAttribute('placeholder', /package to sign/, { timeout: 20_000 });
+            const placeholder = await inputBox.getAttribute('placeholder');
+            expect(placeholder).toContain('package to sign');
 
             // Press Escape to cancel the QuickPick
             await page.keyboard.press('Escape');
             await page.waitForTimeout(2_000);
 
-            // VS Code retains inactive QuickPick rows in the DOM, so assert on
-            // the widget's visibility rather than the row count.
-            await expect(quickInput).toBeHidden({ timeout: 5_000 });
+            // Verify the QuickPick is dismissed — the list rows should no longer
+            // be visible. We check that no quick-input list rows are shown, which
+            // means no second picker (certificate) appeared.
+            const visibleRows = quickInput.locator('.quick-input-list .monaco-list-row');
+            await expect(visibleRows).toHaveCount(0, { timeout: 5_000 });
 
             // Verify no WinApp terminal was created (sign was not executed)
             const terminalTabs = page.locator('.terminal-tab');
@@ -298,14 +278,15 @@ test.describe('winapp.sign command — artifact discovery', () => {
 
             // Wait for the artifact QuickPick to appear
             const quickInput = page.locator('.quick-input-widget');
-            const inputBox = quickInput.locator('.quick-input-filter input[type="text"]');
-            await expect(inputBox).toHaveAttribute('placeholder', /package to sign/, { timeout: 20_000 });
+            await expect(
+                quickInput.locator('.quick-input-list .monaco-list-row').first()
+            ).toBeVisible({ timeout: 20_000 });
 
-            // Select the Browse row by its label rather than position so this
-            // cannot accidentally click a stale Command Palette result.
+            // Click "Browse…" (second item, the last row)
             const items = quickInput.locator('.quick-input-list .monaco-list-row');
-            const browseItem = items.filter({ hasText: 'Browse' });
-            await expect(browseItem).toHaveCount(1, { timeout: 10_000 });
+            const browseItem = items.last();
+            const browseText = await browseItem.textContent();
+            expect(browseText).toContain('Browse');
             await browseItem.click();
 
             // Smoke test only: selecting Browse should dismiss the QuickPick and
@@ -315,11 +296,14 @@ test.describe('winapp.sign command — artifact discovery', () => {
             // VS Code-side handoff happens without an immediate error.
             await page.waitForTimeout(2_000);
 
-            // The QuickPick should no longer be visible (replaced by native dialog).
-            await expect(quickInput).toBeHidden({ timeout: 5_000 });
+            // The QuickPick list should no longer be visible (replaced by native dialog)
+            const visibleRows = quickInput.locator('.quick-input-list .monaco-list-row');
+            await expect(visibleRows).toHaveCount(0, { timeout: 5_000 });
 
             // No error notification should be visible
-            await expect(page.locator('.notification-toast .codicon-error:visible')).toHaveCount(0);
+            const errorNotification = page.locator('.notification-toast .codicon-error');
+            const errorCount = await errorNotification.count();
+            expect(errorCount).toBe(0);
 
             console.log('✅ PASS: Selecting Browse dismissed QuickPick and opened file dialog');
 
@@ -350,24 +334,32 @@ test.describe('winapp.sign command — artifact discovery', () => {
             // Run "WinApp: Sign Package"
             await runCommandPalette(page, 'WinApp: Sign Package');
 
+            // Wait for the artifact QuickPick to appear
             const quickInput = page.locator('.quick-input-widget');
-            const packageInput = quickInput.locator('.quick-input-filter input[type="text"]');
-            await expect(packageInput).toHaveAttribute('placeholder', /package to sign/, { timeout: 20_000 });
+            await expect(
+                quickInput.locator('.quick-input-list .monaco-list-row').first()
+            ).toBeVisible({ timeout: 20_000 });
 
-            const packageItem = quickInput.locator('.quick-input-list .monaco-list-row')
-                .filter({ hasText: 'MyApp_1.0.0.0_x64.msix' });
-            await expect(packageItem).toHaveCount(1, { timeout: 10_000 });
-            await packageItem.click();
+            // Select the .msix artifact (first item) to advance to cert picker
+            await quickInput.locator('.quick-input-list .monaco-list-row').first().click();
 
+            // Wait for the certificate QuickPick to appear
+            await expect(
+                quickInput.locator('.quick-input-list .monaco-list-row').first()
+            ).toBeVisible({ timeout: 20_000 });
+
+            // Verify it's the certificate picker
             const certInput = quickInput.locator('.quick-input-filter input[type="text"]');
-            await expect(certInput).toHaveAttribute('placeholder', /signing certificate/, { timeout: 20_000 });
+            const certPlaceholder = await certInput.getAttribute('placeholder');
+            expect(certPlaceholder).toContain('signing certificate');
 
             // Press Escape to cancel the certificate QuickPick
             await page.keyboard.press('Escape');
             await page.waitForTimeout(2_000);
 
-            // Verify the QuickPick is dismissed.
-            await expect(quickInput).toBeHidden({ timeout: 5_000 });
+            // Verify the QuickPick is dismissed
+            const visibleRows = quickInput.locator('.quick-input-list .monaco-list-row');
+            await expect(visibleRows).toHaveCount(0, { timeout: 5_000 });
 
             // Verify no WinApp terminal was created (sign was not executed)
             const terminalTabs = page.locator('.terminal-tab');

--- a/src/test/e2e/sign-quickpick.spec.ts
+++ b/src/test/e2e/sign-quickpick.spec.ts
@@ -92,6 +92,16 @@ function createSignTestWorkspace(options?: { includePfx?: boolean }): string {
     return tmpDir;
 }
 
+function configureFilesExclude(workspacePath: string): void {
+    const settingsPath = path.join(workspacePath, '.vscode', 'settings.json');
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({
+        'files.exclude': {
+            '**/AppPackages': true
+        }
+    }));
+}
+
 // ──────────────────────────────────────────────────────
 // Test 1 — Workspace with .msix artifact
 // ──────────────────────────────────────────────────────
@@ -141,6 +151,37 @@ test.describe('winapp.sign command — artifact discovery', () => {
             await page.keyboard.press('Escape');
 
             console.log('✅ PASS: QuickPick appeared with .msix artifact and Browse… option');
+        } finally {
+            if (app) {
+                await app.close().catch(() => {});
+            }
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    test('ignores files.exclude without showing dependency artifacts', async () => {
+        const tmpDir = createSignTestWorkspace();
+        configureFilesExclude(tmpDir);
+        const ignoredArtifact = path.join(tmpDir, 'node_modules', 'pkg', 'Ignored.msix');
+        fs.mkdirSync(path.dirname(ignoredArtifact), { recursive: true });
+        fs.writeFileSync(ignoredArtifact, Buffer.alloc(128));
+
+        let app: ElectronApplication | undefined;
+        try {
+            const launched = await launchVSCodeForFolder(tmpDir);
+            app = launched.app;
+            const page = launched.page;
+
+            await runCommandPalette(page, 'WinApp: Sign Package');
+
+            const quickInput = page.locator('.quick-input-widget');
+            const inputBox = quickInput.locator('.quick-input-filter input[type="text"]');
+            await expect(inputBox).toHaveAttribute('placeholder', /package to sign/, { timeout: 20_000 });
+            const itemText = await quickInput.locator('.quick-input-list .monaco-list-row').allTextContents();
+            expect(itemText.join(' ')).toContain('MyApp_1.0.0.0_x64.msix');
+            expect(itemText.join(' ')).not.toContain('Ignored.msix');
+
+            await page.keyboard.press('Escape');
         } finally {
             if (app) {
                 await app.close().catch(() => {});

--- a/src/test/e2e/sign-quickpick.spec.ts
+++ b/src/test/e2e/sign-quickpick.spec.ts
@@ -5,20 +5,24 @@
  *   Opens VS Code in a workspace containing a .msix file, runs "WinApp: Sign Package",
  *   and asserts that a QuickPick appears listing the artifact and a "Browse…" option.
  *
- * Test 2 — Certificate QuickPick:
+ * Test 2 — Discovery exclusions:
+ *   Verifies user `files.exclude` settings do not hide build artifacts while
+ *   `node_modules` and `.git` remain excluded from the QuickPick.
+ *
+ * Test 3 — Certificate QuickPick:
  *   Opens VS Code in a workspace containing both a .msix and a .pfx file, selects
  *   the package, and asserts that a second QuickPick appears for certificate selection.
  *
- * Test 3 — Cancel artifact QuickPick:
+ * Test 4 — Cancel artifact QuickPick:
  *   Opens VS Code, runs "WinApp: Sign Package", and presses Escape to dismiss the
  *   artifact QuickPick. Verifies the sign flow aborts gracefully (no certificate
  *   picker or terminal appears).
  *
- * Test 4 — Browse option:
+ * Test 5 — Browse option:
  *   Opens VS Code, runs "WinApp: Sign Package", selects "Browse…" from the QuickPick,
  *   and verifies that a native file dialog opens (the Open dialog title bar appears).
  *
- * Test 5 — Cancel certificate QuickPick:
+ * Test 6 — Cancel certificate QuickPick:
  *   Opens VS Code, selects an artifact from the package QuickPick, then presses
  *   Escape on the certificate QuickPick. Verifies the sign flow aborts (no terminal).
  */
@@ -92,6 +96,16 @@ function createSignTestWorkspace(options?: { includePfx?: boolean }): string {
     return tmpDir;
 }
 
+function configureFilesExclude(workspacePath: string): void {
+    const settingsPath = path.join(workspacePath, '.vscode', 'settings.json');
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({
+        'files.exclude': {
+            '**/AppPackages': true
+        }
+    }));
+}
+
 // ──────────────────────────────────────────────────────
 // Test 1 — Workspace with .msix artifact
 // ──────────────────────────────────────────────────────
@@ -109,20 +123,9 @@ test.describe('winapp.sign command — artifact discovery', () => {
             // Run "WinApp: Sign Package"
             await runCommandPalette(page, 'WinApp: Sign Package');
 
-            // The QuickPick should appear. Wait for the quick-input widget to
-            // become visible. VS Code keeps the widget in the DOM with
-            // style="display:none" when inactive, so we must also exclude that.
             const quickInput = page.locator('.quick-input-widget');
-            // Wait for either the quick-input list rows or the placeholder to
-            // appear — this accounts for VS Code toggling visibility classes.
-            await expect(
-                quickInput.locator('.quick-input-list .monaco-list-row').first()
-            ).toBeVisible({ timeout: 20_000 });
-
-            // The placeholder text should mention signing
             const inputBox = quickInput.locator('.quick-input-filter input[type="text"]');
-            const placeholder = await inputBox.getAttribute('placeholder');
-            expect(placeholder).toContain('package to sign');
+            await expect(inputBox).toHaveAttribute('placeholder', /package to sign/, { timeout: 20_000 });
 
             // There should be at least 2 items: the .msix file + Browse…
             const items = quickInput.locator('.quick-input-list .monaco-list-row');
@@ -149,6 +152,43 @@ test.describe('winapp.sign command — artifact discovery', () => {
         }
     });
 
+    test('keeps build artifacts visible while excluding dependency and repository metadata', async () => {
+        const tmpDir = createSignTestWorkspace();
+        configureFilesExclude(tmpDir);
+        fs.mkdirSync(path.join(tmpDir, 'node_modules', 'pkg'), { recursive: true });
+        fs.writeFileSync(path.join(tmpDir, 'node_modules', 'pkg', 'Ignored.msix'), Buffer.alloc(128));
+        fs.mkdirSync(path.join(tmpDir, 'vendor', '.git', 'objects'), { recursive: true });
+        fs.writeFileSync(path.join(tmpDir, 'vendor', '.git', 'objects', 'Ignored.appx'), Buffer.alloc(128));
+
+        let app: ElectronApplication | undefined;
+        try {
+            const launched = await launchVSCodeForFolder(tmpDir);
+            app = launched.app;
+            const page = launched.page;
+
+            await runCommandPalette(page, 'WinApp: Sign Package');
+
+            const quickInput = page.locator('.quick-input-widget');
+            const inputBox = quickInput.locator('.quick-input-filter input[type="text"]');
+            await expect(inputBox).toHaveAttribute('placeholder', /package to sign/, { timeout: 20_000 });
+            const items = quickInput.locator('.quick-input-list .monaco-list-row');
+            await expect(items.first()).toBeVisible({ timeout: 20_000 });
+            await expect(items).toHaveCount(2, { timeout: 10_000 });
+
+            const quickPickText = await items.allTextContents();
+            expect(quickPickText.join(' ')).toContain('MyApp_1.0.0.0_x64.msix');
+            expect(quickPickText.join(' ')).not.toContain('Ignored.msix');
+            expect(quickPickText.join(' ')).not.toContain('Ignored.appx');
+
+            await page.keyboard.press('Escape');
+        } finally {
+            if (app) {
+                await app.close().catch(() => {});
+            }
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
     test('shows certificate QuickPick with .pfx file after selecting a package', async () => {
         const tmpDir = createSignTestWorkspace({ includePfx: true });
 
@@ -161,29 +201,18 @@ test.describe('winapp.sign command — artifact discovery', () => {
             // Run "WinApp: Sign Package"
             await runCommandPalette(page, 'WinApp: Sign Package');
 
-            // Wait for the artifact QuickPick to appear
             const quickInput = page.locator('.quick-input-widget');
-            await expect(
-                quickInput.locator('.quick-input-list .monaco-list-row').first()
-            ).toBeVisible({ timeout: 20_000 });
-
-            // Verify it's the package picker
             const packageInput = quickInput.locator('.quick-input-filter input[type="text"]');
-            const packagePlaceholder = await packageInput.getAttribute('placeholder');
-            expect(packagePlaceholder).toContain('package to sign');
+            await expect(packageInput).toHaveAttribute('placeholder', /package to sign/, { timeout: 20_000 });
 
-            // Select the .msix artifact (first item) to advance to cert picker
-            await quickInput.locator('.quick-input-list .monaco-list-row').first().click();
+            // Select the artifact by label so a stale Command Palette row cannot win the race.
+            const packageItem = quickInput.locator('.quick-input-list .monaco-list-row')
+                .filter({ hasText: 'MyApp_1.0.0.0_x64.msix' });
+            await expect(packageItem).toHaveCount(1, { timeout: 10_000 });
+            await packageItem.click();
 
-            // Wait for the certificate QuickPick to appear (second picker)
-            await expect(
-                quickInput.locator('.quick-input-list .monaco-list-row').first()
-            ).toBeVisible({ timeout: 20_000 });
-
-            // The placeholder should now mention certificate
             const certInput = quickInput.locator('.quick-input-filter input[type="text"]');
-            const certPlaceholder = await certInput.getAttribute('placeholder');
-            expect(certPlaceholder).toContain('signing certificate');
+            await expect(certInput).toHaveAttribute('placeholder', /signing certificate/, { timeout: 20_000 });
 
             // There should be 2 items: the .pfx file + Browse…
             const certItems = quickInput.locator('.quick-input-list .monaco-list-row');
@@ -225,26 +254,17 @@ test.describe('winapp.sign command — artifact discovery', () => {
             // Run "WinApp: Sign Package"
             await runCommandPalette(page, 'WinApp: Sign Package');
 
-            // Wait for the artifact QuickPick to appear
             const quickInput = page.locator('.quick-input-widget');
-            await expect(
-                quickInput.locator('.quick-input-list .monaco-list-row').first()
-            ).toBeVisible({ timeout: 20_000 });
-
-            // Verify it's the package picker
             const inputBox = quickInput.locator('.quick-input-filter input[type="text"]');
-            const placeholder = await inputBox.getAttribute('placeholder');
-            expect(placeholder).toContain('package to sign');
+            await expect(inputBox).toHaveAttribute('placeholder', /package to sign/, { timeout: 20_000 });
 
             // Press Escape to cancel the QuickPick
             await page.keyboard.press('Escape');
             await page.waitForTimeout(2_000);
 
-            // Verify the QuickPick is dismissed — the list rows should no longer
-            // be visible. We check that no quick-input list rows are shown, which
-            // means no second picker (certificate) appeared.
-            const visibleRows = quickInput.locator('.quick-input-list .monaco-list-row');
-            await expect(visibleRows).toHaveCount(0, { timeout: 5_000 });
+            // VS Code retains inactive QuickPick rows in the DOM, so assert on
+            // the widget's visibility rather than the row count.
+            await expect(quickInput).toBeHidden({ timeout: 5_000 });
 
             // Verify no WinApp terminal was created (sign was not executed)
             const terminalTabs = page.locator('.terminal-tab');
@@ -278,15 +298,14 @@ test.describe('winapp.sign command — artifact discovery', () => {
 
             // Wait for the artifact QuickPick to appear
             const quickInput = page.locator('.quick-input-widget');
-            await expect(
-                quickInput.locator('.quick-input-list .monaco-list-row').first()
-            ).toBeVisible({ timeout: 20_000 });
+            const inputBox = quickInput.locator('.quick-input-filter input[type="text"]');
+            await expect(inputBox).toHaveAttribute('placeholder', /package to sign/, { timeout: 20_000 });
 
-            // Click "Browse…" (second item, the last row)
+            // Select the Browse row by its label rather than position so this
+            // cannot accidentally click a stale Command Palette result.
             const items = quickInput.locator('.quick-input-list .monaco-list-row');
-            const browseItem = items.last();
-            const browseText = await browseItem.textContent();
-            expect(browseText).toContain('Browse');
+            const browseItem = items.filter({ hasText: 'Browse' });
+            await expect(browseItem).toHaveCount(1, { timeout: 10_000 });
             await browseItem.click();
 
             // Smoke test only: selecting Browse should dismiss the QuickPick and
@@ -296,14 +315,11 @@ test.describe('winapp.sign command — artifact discovery', () => {
             // VS Code-side handoff happens without an immediate error.
             await page.waitForTimeout(2_000);
 
-            // The QuickPick list should no longer be visible (replaced by native dialog)
-            const visibleRows = quickInput.locator('.quick-input-list .monaco-list-row');
-            await expect(visibleRows).toHaveCount(0, { timeout: 5_000 });
+            // The QuickPick should no longer be visible (replaced by native dialog).
+            await expect(quickInput).toBeHidden({ timeout: 5_000 });
 
             // No error notification should be visible
-            const errorNotification = page.locator('.notification-toast .codicon-error');
-            const errorCount = await errorNotification.count();
-            expect(errorCount).toBe(0);
+            await expect(page.locator('.notification-toast .codicon-error:visible')).toHaveCount(0);
 
             console.log('✅ PASS: Selecting Browse dismissed QuickPick and opened file dialog');
 
@@ -334,32 +350,24 @@ test.describe('winapp.sign command — artifact discovery', () => {
             // Run "WinApp: Sign Package"
             await runCommandPalette(page, 'WinApp: Sign Package');
 
-            // Wait for the artifact QuickPick to appear
             const quickInput = page.locator('.quick-input-widget');
-            await expect(
-                quickInput.locator('.quick-input-list .monaco-list-row').first()
-            ).toBeVisible({ timeout: 20_000 });
+            const packageInput = quickInput.locator('.quick-input-filter input[type="text"]');
+            await expect(packageInput).toHaveAttribute('placeholder', /package to sign/, { timeout: 20_000 });
 
-            // Select the .msix artifact (first item) to advance to cert picker
-            await quickInput.locator('.quick-input-list .monaco-list-row').first().click();
+            const packageItem = quickInput.locator('.quick-input-list .monaco-list-row')
+                .filter({ hasText: 'MyApp_1.0.0.0_x64.msix' });
+            await expect(packageItem).toHaveCount(1, { timeout: 10_000 });
+            await packageItem.click();
 
-            // Wait for the certificate QuickPick to appear
-            await expect(
-                quickInput.locator('.quick-input-list .monaco-list-row').first()
-            ).toBeVisible({ timeout: 20_000 });
-
-            // Verify it's the certificate picker
             const certInput = quickInput.locator('.quick-input-filter input[type="text"]');
-            const certPlaceholder = await certInput.getAttribute('placeholder');
-            expect(certPlaceholder).toContain('signing certificate');
+            await expect(certInput).toHaveAttribute('placeholder', /signing certificate/, { timeout: 20_000 });
 
             // Press Escape to cancel the certificate QuickPick
             await page.keyboard.press('Escape');
             await page.waitForTimeout(2_000);
 
-            // Verify the QuickPick is dismissed
-            const visibleRows = quickInput.locator('.quick-input-list .monaco-list-row');
-            await expect(visibleRows).toHaveCount(0, { timeout: 5_000 });
+            // Verify the QuickPick is dismissed.
+            await expect(quickInput).toBeHidden({ timeout: 5_000 });
 
             // Verify no WinApp terminal was created (sign was not executed)
             const terminalTabs = page.locator('.terminal-tab');

--- a/src/test/sign-utils.test.ts
+++ b/src/test/sign-utils.test.ts
@@ -3,7 +3,12 @@ import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { findWorkspaceArtifacts, buildSignCommand, CERTIFICATE_GLOBS } from '../sign-utils';
+import {
+	findWorkspaceArtifacts,
+	buildSignCommand,
+	CERTIFICATE_GLOBS,
+	type WorkspaceFileFinder
+} from '../sign-utils';
 import { ARTIFACT_GLOBS } from '../artifact-types';
 
 function createTempDir(): string {
@@ -25,6 +30,10 @@ function createFile(filePath: string, mtimeMs?: number): void {
 
 const tempDirs: string[] = [];
 
+function findFiles(...filePaths: string[]): WorkspaceFileFinder {
+	return async () => filePaths;
+}
+
 afterEach(() => {
 	for (const dir of tempDirs.splice(0)) {
 		removeTempDir(dir);
@@ -35,12 +44,15 @@ describe('findWorkspaceArtifacts', () => {
 	it('discovers .msix, .msixbundle, .appx, and .appxbundle files', async () => {
 		const tempDir = createTempDir();
 		tempDirs.push(tempDir);
-		createFile(path.join(tempDir, 'a.msix'));
-		createFile(path.join(tempDir, 'b.msixbundle'));
-		createFile(path.join(tempDir, 'c.appx'));
-		createFile(path.join(tempDir, 'd.appxbundle'));
+		const files = [
+			path.join(tempDir, 'a.msix'),
+			path.join(tempDir, 'b.msixbundle'),
+			path.join(tempDir, 'c.appx'),
+			path.join(tempDir, 'd.appxbundle')
+		];
+		files.forEach(filePath => createFile(filePath));
 
-		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, findFiles(...files), ARTIFACT_GLOBS);
 
 		assert.deepEqual(
 			results.map(filePath => path.basename(filePath)).sort(),
@@ -58,7 +70,11 @@ describe('findWorkspaceArtifacts', () => {
 		createFile(newest, 1_700_000_000_200);
 		createFile(middle, 1_700_000_000_100);
 
-		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
+		const results = await findWorkspaceArtifacts(
+			tempDir,
+			findFiles(older, newest, middle),
+			ARTIFACT_GLOBS
+		);
 
 		assert.deepEqual(results, [newest, middle, older]);
 	});
@@ -81,7 +97,11 @@ describe('findWorkspaceArtifacts', () => {
 		}) as typeof fs.promises.stat;
 
 		try {
-			const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
+			const results = await findWorkspaceArtifacts(
+				tempDir,
+				findFiles(stable, missing),
+				ARTIFACT_GLOBS
+			);
 			assert.deepEqual(results, [stable, missing]);
 		} finally {
 			promisesFs.stat = originalStat;
@@ -92,7 +112,7 @@ describe('findWorkspaceArtifacts', () => {
 		const tempDir = createTempDir();
 		tempDirs.push(tempDir);
 
-		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, findFiles(), ARTIFACT_GLOBS);
 
 		assert.deepEqual(results, []);
 	});
@@ -103,7 +123,7 @@ describe('findWorkspaceArtifacts', () => {
 		const nested = path.join(tempDir, 'artifacts', 'release', 'app.msix');
 		createFile(nested);
 
-		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, findFiles(nested), ARTIFACT_GLOBS);
 
 		assert.deepEqual(results, [nested]);
 	});
@@ -113,12 +133,124 @@ describe('findWorkspaceArtifacts', () => {
 		tempDirs.push(tempDir);
 		const included = path.join(tempDir, 'out', 'app.msix');
 		createFile(included);
-		createFile(path.join(tempDir, 'node_modules', 'pkg', 'ignored.msix'));
-		createFile(path.join(tempDir, '.git', 'objects', 'ignored.appx'));
+		const dependency = path.join(tempDir, 'node_modules', 'pkg', 'ignored.msix');
+		const repositoryMetadata = path.join(tempDir, '.git', 'objects', 'ignored.appx');
+		createFile(dependency);
+		createFile(repositoryMetadata);
 
-		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
+		const results = await findWorkspaceArtifacts(
+			tempDir,
+			findFiles(included, dependency, repositoryMetadata),
+			ARTIFACT_GLOBS
+		);
 
 		assert.deepEqual(results, [included]);
+	});
+
+	it('searches all artifact extensions in one call', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		let receivedPattern: string | undefined;
+		let calls = 0;
+
+		await findWorkspaceArtifacts(
+			tempDir,
+			async (includePattern) => {
+				calls++;
+				receivedPattern = includePattern;
+				return [];
+			},
+			ARTIFACT_GLOBS
+		);
+
+		assert.equal(calls, 1);
+		assert.equal(receivedPattern, `{${ARTIFACT_GLOBS.join(',')}}`);
+	});
+
+	it('does not start discovery when already aborted', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const controller = new AbortController();
+		controller.abort();
+		let called = false;
+
+		const results = await findWorkspaceArtifacts(
+			tempDir,
+			async () => {
+				called = true;
+				return [];
+			},
+			ARTIFACT_GLOBS,
+			controller.signal
+		);
+
+		assert.deepEqual(results, []);
+		assert.equal(called, false);
+	});
+
+	it('stops an in-progress workspace search when aborted', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const controller = new AbortController();
+		const search = findWorkspaceArtifacts(
+			tempDir,
+			(_includePattern, signal) => new Promise((_resolve, reject) => {
+				signal?.addEventListener('abort', () => {
+					reject(Object.assign(new Error('Cancelled'), { name: 'Canceled' }));
+				}, { once: true });
+			}),
+			ARTIFACT_GLOBS,
+			controller.signal
+		);
+
+		controller.abort();
+
+		assert.deepEqual(await search, []);
+	});
+
+	it('stops stat work after cancellation', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const controller = new AbortController();
+		const first = path.join(tempDir, 'first.msix');
+		const second = path.join(tempDir, 'second.msix');
+		createFile(first);
+		createFile(second);
+		const promisesFs = fs.promises as { stat: typeof fs.promises.stat };
+		const originalStat = promisesFs.stat;
+		let statCalls = 0;
+		promisesFs.stat = (async (targetPath: fs.PathLike) => {
+			statCalls++;
+			controller.abort();
+			return originalStat(targetPath);
+		}) as typeof fs.promises.stat;
+
+		try {
+			const results = await findWorkspaceArtifacts(
+				tempDir,
+				findFiles(first, second),
+				ARTIFACT_GLOBS,
+				controller.signal
+			);
+			assert.deepEqual(results, []);
+			assert.equal(statCalls, 1);
+		} finally {
+			promisesFs.stat = originalStat;
+		}
+	});
+
+	it('propagates non-cancellation search errors', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+
+		await assert.rejects(
+			findWorkspaceArtifacts(
+				tempDir,
+				async () => { throw new Error('search failed'); },
+				ARTIFACT_GLOBS
+			),
+			/search failed/
+		);
 	});
 });
 
@@ -126,10 +258,13 @@ describe('findWorkspaceArtifacts with CERTIFICATE_GLOBS', () => {
 	it('discovers .pfx certificate files', async () => {
 		const tempDir = createTempDir();
 		tempDirs.push(tempDir);
-		createFile(path.join(tempDir, 'devcert.pfx'));
-		createFile(path.join(tempDir, 'certs', 'prod.pfx'));
+		const files = [
+			path.join(tempDir, 'devcert.pfx'),
+			path.join(tempDir, 'certs', 'prod.pfx')
+		];
+		files.forEach(filePath => createFile(filePath));
 
-		const results = await findWorkspaceArtifacts(tempDir, CERTIFICATE_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, findFiles(...files), CERTIFICATE_GLOBS);
 
 		assert.deepEqual(
 			results.map(filePath => path.basename(filePath)).sort(),
@@ -143,7 +278,7 @@ describe('findWorkspaceArtifacts with CERTIFICATE_GLOBS', () => {
 		createFile(path.join(tempDir, 'app.msix'));
 		createFile(path.join(tempDir, 'cert.pem'));
 
-		const results = await findWorkspaceArtifacts(tempDir, CERTIFICATE_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, findFiles(), CERTIFICATE_GLOBS);
 
 		assert.deepEqual(results, []);
 	});
@@ -153,9 +288,14 @@ describe('findWorkspaceArtifacts with CERTIFICATE_GLOBS', () => {
 		tempDirs.push(tempDir);
 		const included = path.join(tempDir, 'devcert.pfx');
 		createFile(included);
-		createFile(path.join(tempDir, 'node_modules', 'pkg', 'test.pfx'));
+		const dependency = path.join(tempDir, 'node_modules', 'pkg', 'test.pfx');
+		createFile(dependency);
 
-		const results = await findWorkspaceArtifacts(tempDir, CERTIFICATE_GLOBS);
+		const results = await findWorkspaceArtifacts(
+			tempDir,
+			findFiles(included, dependency),
+			CERTIFICATE_GLOBS
+		);
 
 		assert.deepEqual(results, [included]);
 	});

--- a/src/test/sign-utils.test.ts
+++ b/src/test/sign-utils.test.ts
@@ -3,11 +3,11 @@ import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { glob } from 'glob';
 import {
-	findWorkspaceArtifacts,
+	findWorkspaceArtifacts as findWorkspaceArtifactsCore,
 	buildSignCommand,
-	CERTIFICATE_GLOBS,
-	type WorkspaceFileFinder
+	CERTIFICATE_GLOBS
 } from '../sign-utils';
 import { ARTIFACT_GLOBS } from '../artifact-types';
 
@@ -30,8 +30,17 @@ function createFile(filePath: string, mtimeMs?: number): void {
 
 const tempDirs: string[] = [];
 
-function findFiles(...filePaths: string[]): WorkspaceFileFinder {
-	return async () => filePaths;
+function findWorkspaceArtifacts(
+	workspacePath: string,
+	patterns: string[] = ARTIFACT_GLOBS,
+	signal?: AbortSignal
+): Promise<string[]> {
+	return findWorkspaceArtifactsCore(
+		workspacePath,
+		includePattern => glob(includePattern, { cwd: workspacePath, absolute: true, nodir: true }),
+		patterns,
+		signal
+	);
 }
 
 afterEach(() => {
@@ -44,15 +53,12 @@ describe('findWorkspaceArtifacts', () => {
 	it('discovers .msix, .msixbundle, .appx, and .appxbundle files', async () => {
 		const tempDir = createTempDir();
 		tempDirs.push(tempDir);
-		const files = [
-			path.join(tempDir, 'a.msix'),
-			path.join(tempDir, 'b.msixbundle'),
-			path.join(tempDir, 'c.appx'),
-			path.join(tempDir, 'd.appxbundle')
-		];
-		files.forEach(filePath => createFile(filePath));
+		createFile(path.join(tempDir, 'a.msix'));
+		createFile(path.join(tempDir, 'b.msixbundle'));
+		createFile(path.join(tempDir, 'c.appx'));
+		createFile(path.join(tempDir, 'd.appxbundle'));
 
-		const results = await findWorkspaceArtifacts(tempDir, findFiles(...files), ARTIFACT_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
 
 		assert.deepEqual(
 			results.map(filePath => path.basename(filePath)).sort(),
@@ -70,11 +76,7 @@ describe('findWorkspaceArtifacts', () => {
 		createFile(newest, 1_700_000_000_200);
 		createFile(middle, 1_700_000_000_100);
 
-		const results = await findWorkspaceArtifacts(
-			tempDir,
-			findFiles(older, newest, middle),
-			ARTIFACT_GLOBS
-		);
+		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
 
 		assert.deepEqual(results, [newest, middle, older]);
 	});
@@ -97,11 +99,7 @@ describe('findWorkspaceArtifacts', () => {
 		}) as typeof fs.promises.stat;
 
 		try {
-			const results = await findWorkspaceArtifacts(
-				tempDir,
-				findFiles(stable, missing),
-				ARTIFACT_GLOBS
-			);
+			const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
 			assert.deepEqual(results, [stable, missing]);
 		} finally {
 			promisesFs.stat = originalStat;
@@ -112,7 +110,7 @@ describe('findWorkspaceArtifacts', () => {
 		const tempDir = createTempDir();
 		tempDirs.push(tempDir);
 
-		const results = await findWorkspaceArtifacts(tempDir, findFiles(), ARTIFACT_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
 
 		assert.deepEqual(results, []);
 	});
@@ -123,7 +121,7 @@ describe('findWorkspaceArtifacts', () => {
 		const nested = path.join(tempDir, 'artifacts', 'release', 'app.msix');
 		createFile(nested);
 
-		const results = await findWorkspaceArtifacts(tempDir, findFiles(nested), ARTIFACT_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
 
 		assert.deepEqual(results, [nested]);
 	});
@@ -133,16 +131,10 @@ describe('findWorkspaceArtifacts', () => {
 		tempDirs.push(tempDir);
 		const included = path.join(tempDir, 'out', 'app.msix');
 		createFile(included);
-		const dependency = path.join(tempDir, 'node_modules', 'pkg', 'ignored.msix');
-		const repositoryMetadata = path.join(tempDir, '.git', 'objects', 'ignored.appx');
-		createFile(dependency);
-		createFile(repositoryMetadata);
+		createFile(path.join(tempDir, 'node_modules', 'pkg', 'ignored.msix'));
+		createFile(path.join(tempDir, '.git', 'objects', 'ignored.appx'));
 
-		const results = await findWorkspaceArtifacts(
-			tempDir,
-			findFiles(included, dependency, repositoryMetadata),
-			ARTIFACT_GLOBS
-		);
+		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
 
 		assert.deepEqual(results, [included]);
 	});
@@ -153,7 +145,7 @@ describe('findWorkspaceArtifacts', () => {
 		let receivedPattern: string | undefined;
 		let calls = 0;
 
-		await findWorkspaceArtifacts(
+		await findWorkspaceArtifactsCore(
 			tempDir,
 			async (includePattern) => {
 				calls++;
@@ -174,7 +166,7 @@ describe('findWorkspaceArtifacts', () => {
 		controller.abort();
 		let called = false;
 
-		const results = await findWorkspaceArtifacts(
+		const results = await findWorkspaceArtifactsCore(
 			tempDir,
 			async () => {
 				called = true;
@@ -192,7 +184,7 @@ describe('findWorkspaceArtifacts', () => {
 		const tempDir = createTempDir();
 		tempDirs.push(tempDir);
 		const controller = new AbortController();
-		const search = findWorkspaceArtifacts(
+		const search = findWorkspaceArtifactsCore(
 			tempDir,
 			(_includePattern, signal) => new Promise((_resolve, reject) => {
 				signal?.addEventListener('abort', () => {
@@ -226,9 +218,9 @@ describe('findWorkspaceArtifacts', () => {
 		}) as typeof fs.promises.stat;
 
 		try {
-			const results = await findWorkspaceArtifacts(
+			const results = await findWorkspaceArtifactsCore(
 				tempDir,
-				findFiles(first, second),
+				async () => [first, second],
 				ARTIFACT_GLOBS,
 				controller.signal
 			);
@@ -244,7 +236,7 @@ describe('findWorkspaceArtifacts', () => {
 		tempDirs.push(tempDir);
 
 		await assert.rejects(
-			findWorkspaceArtifacts(
+			findWorkspaceArtifactsCore(
 				tempDir,
 				async () => { throw new Error('search failed'); },
 				ARTIFACT_GLOBS
@@ -258,13 +250,10 @@ describe('findWorkspaceArtifacts with CERTIFICATE_GLOBS', () => {
 	it('discovers .pfx certificate files', async () => {
 		const tempDir = createTempDir();
 		tempDirs.push(tempDir);
-		const files = [
-			path.join(tempDir, 'devcert.pfx'),
-			path.join(tempDir, 'certs', 'prod.pfx')
-		];
-		files.forEach(filePath => createFile(filePath));
+		createFile(path.join(tempDir, 'devcert.pfx'));
+		createFile(path.join(tempDir, 'certs', 'prod.pfx'));
 
-		const results = await findWorkspaceArtifacts(tempDir, findFiles(...files), CERTIFICATE_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, CERTIFICATE_GLOBS);
 
 		assert.deepEqual(
 			results.map(filePath => path.basename(filePath)).sort(),
@@ -278,7 +267,7 @@ describe('findWorkspaceArtifacts with CERTIFICATE_GLOBS', () => {
 		createFile(path.join(tempDir, 'app.msix'));
 		createFile(path.join(tempDir, 'cert.pem'));
 
-		const results = await findWorkspaceArtifacts(tempDir, findFiles(), CERTIFICATE_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, CERTIFICATE_GLOBS);
 
 		assert.deepEqual(results, []);
 	});
@@ -288,14 +277,9 @@ describe('findWorkspaceArtifacts with CERTIFICATE_GLOBS', () => {
 		tempDirs.push(tempDir);
 		const included = path.join(tempDir, 'devcert.pfx');
 		createFile(included);
-		const dependency = path.join(tempDir, 'node_modules', 'pkg', 'test.pfx');
-		createFile(dependency);
+		createFile(path.join(tempDir, 'node_modules', 'pkg', 'test.pfx'));
 
-		const results = await findWorkspaceArtifacts(
-			tempDir,
-			findFiles(included, dependency),
-			CERTIFICATE_GLOBS
-		);
+		const results = await findWorkspaceArtifacts(tempDir, CERTIFICATE_GLOBS);
 
 		assert.deepEqual(results, [included]);
 	});

--- a/src/test/sign-utils.test.ts
+++ b/src/test/sign-utils.test.ts
@@ -3,22 +3,7 @@ import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import {
-	findWorkspaceArtifacts,
-	buildSignCommand,
-	coordinateWorkspaceSignFileSelection,
-	CERTIFICATE_GLOBS,
-	createSignBrowseItem,
-	createWorkspaceSignFileQuickPickItem,
-	discoverSignFilesWithFallback,
-	handoffSignFileDiscovery,
-	runWithCancellation,
-	runWithCancellationSource,
-	WORKSPACE_ARTIFACT_MAX_RESULTS,
-	WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT,
-	type CancellationTokenLike,
-	type WorkspaceFileFinder
-} from '../sign-utils';
+import { findWorkspaceArtifacts, buildSignCommand, CERTIFICATE_GLOBS } from '../sign-utils';
 import { ARTIFACT_GLOBS } from '../artifact-types';
 
 function createTempDir(): string {
@@ -35,37 +20,6 @@ function createFile(filePath: string, mtimeMs?: number): void {
 	if (mtimeMs !== undefined) {
 		const time = new Date(mtimeMs);
 		fs.utimesSync(filePath, time, time);
-	}
-}
-
-function createFinder(results: string[]): WorkspaceFileFinder {
-	return async () => results;
-}
-
-class ControlledCancellationToken implements CancellationTokenLike {
-	isCancellationRequested = false;
-	disposeCount = 0;
-	private readonly listeners = new Set<() => void>();
-
-	onCancellationRequested(listener: () => void): { dispose(): void } {
-		this.listeners.add(listener);
-		return {
-			dispose: () => {
-				this.disposeCount++;
-				this.listeners.delete(listener);
-			}
-		};
-	}
-
-	cancel(): void {
-		this.isCancellationRequested = true;
-		for (const listener of this.listeners) {
-			listener();
-		}
-	}
-
-	get listenerCount(): number {
-		return this.listeners.size;
 	}
 }
 
@@ -86,16 +40,10 @@ describe('findWorkspaceArtifacts', () => {
 		createFile(path.join(tempDir, 'c.appx'));
 		createFile(path.join(tempDir, 'd.appxbundle'));
 
-		const files = [
-			path.join(tempDir, 'a.msix'),
-			path.join(tempDir, 'b.msixbundle'),
-			path.join(tempDir, 'c.appx'),
-			path.join(tempDir, 'd.appxbundle')
-		];
-		const results = await findWorkspaceArtifacts(tempDir, createFinder(files), ARTIFACT_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
 
 		assert.deepEqual(
-			results.paths.map(filePath => path.basename(filePath)).sort(),
+			results.map(filePath => path.basename(filePath)).sort(),
 			['a.msix', 'b.msixbundle', 'c.appx', 'd.appxbundle']
 		);
 	});
@@ -110,165 +58,9 @@ describe('findWorkspaceArtifacts', () => {
 		createFile(newest, 1_700_000_000_200);
 		createFile(middle, 1_700_000_000_100);
 
-		const results = await findWorkspaceArtifacts(tempDir, createFinder([older, newest, middle]), ARTIFACT_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
 
-		assert.deepEqual(results, {
-			paths: [newest, middle, older],
-			sourceTruncated: false,
-			displayTruncated: false
-		});
-	});
-
-	it('does not report display truncation for exactly 100 valid candidates', async () => {
-		const tempDir = createTempDir();
-		tempDirs.push(tempDir);
-		const files = Array.from(
-			{ length: WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT },
-			(_, index) => path.join(tempDir, `${index}.msix`)
-		);
-		for (const [index, file] of files.entries()) {
-			createFile(file, 1_700_000_000_000 + index);
-		}
-
-		const results = await findWorkspaceArtifacts(tempDir, createFinder(files), ARTIFACT_GLOBS);
-
-		assert.equal(results.paths.length, WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT);
-		assert.equal(results.paths[0], files.at(-1));
-		assert.equal(results.paths.at(-1), files[0]);
-		assert.equal(results.sourceTruncated, false);
-		assert.equal(results.displayTruncated, false);
-	});
-
-	it('reports display truncation for exactly 101 valid candidates and keeps the newest 100', async () => {
-		const tempDir = createTempDir();
-		tempDirs.push(tempDir);
-		const files = Array.from(
-			{ length: WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT + 1 },
-			(_, index) => path.join(tempDir, `${index}.msix`)
-		);
-		for (const [index, file] of files.entries()) {
-			createFile(file, 1_700_000_000_000 + index);
-		}
-		const newest = files.at(-1)!;
-
-		const results = await findWorkspaceArtifacts(tempDir, createFinder(files), ARTIFACT_GLOBS);
-
-		assert.equal(results.paths.length, WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT);
-		assert.equal(results.paths[0], newest);
-		assert.ok(results.paths.includes(newest));
-		assert.equal(results.sourceTruncated, false);
-		assert.equal(results.displayTruncated, true);
-	});
-
-	it('does not report source truncation for exactly 500 source candidates', async () => {
-		const tempDir = createTempDir();
-		tempDirs.push(tempDir);
-		const files = Array.from(
-			{ length: WORKSPACE_ARTIFACT_MAX_RESULTS },
-			(_, index) => path.join(tempDir, `${index}.msix`)
-		);
-		for (const [index, file] of files.entries()) {
-			createFile(file, 1_700_000_000_000 + index);
-		}
-
-		const result = await findWorkspaceArtifacts(tempDir, createFinder(files), ARTIFACT_GLOBS);
-
-		assert.equal(result.sourceTruncated, false);
-		assert.equal(result.displayTruncated, true);
-		assert.equal(result.paths.length, WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT);
-		assert.equal(result.paths[0], files[WORKSPACE_ARTIFACT_MAX_RESULTS - 1]);
-		assert.equal(result.paths.at(-1), files[WORKSPACE_ARTIFACT_MAX_RESULTS - WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT]);
-	});
-
-	it('requests one extra candidate and reports truncation for exactly 501 source candidates while processing only 500', async () => {
-		const tempDir = createTempDir();
-		tempDirs.push(tempDir);
-		const files = Array.from(
-			{ length: WORKSPACE_ARTIFACT_MAX_RESULTS + 1 },
-			(_, index) => path.join(tempDir, `${index}.msix`)
-		);
-		for (const [index, file] of files.entries()) {
-			createFile(file, 1_700_000_000_000 + index);
-		}
-
-		const result = await findWorkspaceArtifacts(tempDir, createFinder(files), ARTIFACT_GLOBS);
-
-		assert.equal(result.sourceTruncated, true);
-		assert.equal(result.displayTruncated, true);
-		assert.equal(result.paths.length, WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT);
-		assert.ok(!result.paths.includes(files.at(-1)!));
-		assert.equal(result.paths[0], files[WORKSPACE_ARTIFACT_MAX_RESULTS - 1]);
-	});
-
-	it('warns before manual selection when all 501 source candidates are post-filtered', async () => {
-		const tempDir = createTempDir();
-		tempDirs.push(tempDir);
-		const files = Array.from(
-			{ length: WORKSPACE_ARTIFACT_MAX_RESULTS + 1 },
-			(_, index) => path.join(tempDir, 'node_modules', `${index}.msix`)
-		);
-
-		const discovery = await findWorkspaceArtifacts(tempDir, createFinder(files), ARTIFACT_GLOBS);
-
-		assert.deepEqual(discovery, {
-			paths: [],
-			sourceTruncated: true,
-			displayTruncated: false
-		});
-
-		let warning = '';
-		let manualCalls = 0;
-		const result = await handoffSignFileDiscovery(
-			{ cancelled: false, result: discovery },
-			async () => {
-				manualCalls++;
-				return 'C:\\manual\\app.msix';
-			},
-			{
-				searchContext: 'signable artifacts',
-				showWarning: async message => {
-					warning = message;
-					return 'Browse…';
-				}
-			}
-		);
-		assert.match(warning, /first 500 workspace matches/i);
-		assert.match(warning, /signable artifacts/i);
-		assert.match(warning, /additional matching files may still exist/i);
-		assert.equal(result, 'C:\\manual\\app.msix');
-		assert.equal(manualCalls, 1);
-	});
-
-	it('offers a clearly labeled Browse path when valid paths remain after source truncation', async () => {
-		const tempDir = createTempDir();
-		tempDirs.push(tempDir);
-		const excluded = Array.from(
-			{ length: WORKSPACE_ARTIFACT_MAX_RESULTS - 2 },
-			(_, index) => path.join(tempDir, 'node_modules', `${index}.msix`)
-		);
-		const valid = [
-			path.join(tempDir, 'output', 'app.msix'),
-			path.join(tempDir, 'output', 'app.appx')
-		];
-		const uninspected = path.join(tempDir, 'output', 'uninspected.msix');
-		for (const file of valid) {
-			createFile(file);
-		}
-
-		const discovery = await findWorkspaceArtifacts(
-			tempDir,
-			createFinder([...excluded, ...valid, uninspected]),
-			ARTIFACT_GLOBS
-		);
-
-		assert.deepEqual(discovery, {
-			paths: valid,
-			sourceTruncated: true,
-			displayTruncated: false
-		});
-		const browseItem = createSignBrowseItem(discovery);
-		assert.match(browseItem.label, /browse/i);
-		assert.match(browseItem.label, /additional files may exist/i);
+		assert.deepEqual(results, [newest, middle, older]);
 	});
 
 	it('tolerates stat failures by pushing those files to the end', async () => {
@@ -289,12 +81,8 @@ describe('findWorkspaceArtifacts', () => {
 		}) as typeof fs.promises.stat;
 
 		try {
-			const results = await findWorkspaceArtifacts(tempDir, createFinder([stable, missing]), ARTIFACT_GLOBS);
-			assert.deepEqual(results, {
-				paths: [stable, missing],
-				sourceTruncated: false,
-				displayTruncated: false
-			});
+			const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
+			assert.deepEqual(results, [stable, missing]);
 		} finally {
 			promisesFs.stat = originalStat;
 		}
@@ -304,9 +92,9 @@ describe('findWorkspaceArtifacts', () => {
 		const tempDir = createTempDir();
 		tempDirs.push(tempDir);
 
-		const results = await findWorkspaceArtifacts(tempDir, createFinder([]), ARTIFACT_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
 
-		assert.deepEqual(results, { paths: [], sourceTruncated: false, displayTruncated: false });
+		assert.deepEqual(results, []);
 	});
 
 	it('discovers files in subdirectories', async () => {
@@ -315,708 +103,22 @@ describe('findWorkspaceArtifacts', () => {
 		const nested = path.join(tempDir, 'artifacts', 'release', 'app.msix');
 		createFile(nested);
 
-		const results = await findWorkspaceArtifacts(tempDir, createFinder([nested]), ARTIFACT_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
 
-		assert.deepEqual(results, {
-			paths: [nested],
-			sourceTruncated: false,
-			displayTruncated: false
-		});
+		assert.deepEqual(results, [nested]);
 	});
 
-	it('uses one brace-pattern search', async () => {
-		let callCount = 0;
-		const finder: WorkspaceFileFinder = async (includePattern, _signal, maxResults) => {
-			callCount++;
-			assert.equal(includePattern, '{**/*.msix,**/*.msixbundle,**/*.appx,**/*.appxbundle}');
-			assert.equal(maxResults, WORKSPACE_ARTIFACT_MAX_RESULTS + 1);
-			return [];
-		};
-
-		await findWorkspaceArtifacts('C:\\workspace', finder, ARTIFACT_GLOBS);
-
-		assert.equal(callCount, 1);
-	});
-
-	it('filters ignored matches before capping results for the QuickPick', async () => {
+	it('excludes node_modules and .git directories', async () => {
 		const tempDir = createTempDir();
 		tempDirs.push(tempDir);
-		const ignored = Array.from(
-			{ length: WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT },
-			(_, index) => path.join(tempDir, 'node_modules', `${index}.msix`)
-		);
-		const valid = Array.from(
-			{ length: WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT + 1 },
-			(_, index) => path.join(tempDir, 'output', `${index}.msix`)
-		);
-		for (const file of [...ignored, ...valid]) {
-			createFile(file);
-		}
-
-		const results = await findWorkspaceArtifacts(
-			tempDir,
-			createFinder([...ignored, ...valid]),
-			ARTIFACT_GLOBS
-		);
-
-		assert.equal(results.paths.length, WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT);
-		assert.ok(results.paths.every(file => file.includes(`${path.sep}output${path.sep}`)));
-		assert.equal(results.sourceTruncated, false);
-		assert.equal(results.displayTruncated, true);
-	});
-
-	it('excludes node_modules and .git results without applying user file exclusions', async () => {
-		const tempDir = createTempDir();
-		tempDirs.push(tempDir);
-		const included = path.join(tempDir, 'AppPackages', 'app.msix');
-		const dependency = path.join(tempDir, 'node_modules', 'pkg', 'ignored.msix');
-		const repositoryMetadata = path.join(tempDir, 'vendor', '.git', 'objects', 'ignored.appx');
+		const included = path.join(tempDir, 'out', 'app.msix');
 		createFile(included);
-		createFile(dependency);
-		createFile(repositoryMetadata);
+		createFile(path.join(tempDir, 'node_modules', 'pkg', 'ignored.msix'));
+		createFile(path.join(tempDir, '.git', 'objects', 'ignored.appx'));
 
-		const results = await findWorkspaceArtifacts(
-			tempDir,
-			createFinder([included, dependency, repositoryMetadata]),
-			ARTIFACT_GLOBS
-		);
+		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
 
-		assert.deepEqual(results, {
-			paths: [included],
-			sourceTruncated: false,
-			displayTruncated: false
-		});
-	});
-
-	it('excludes mixed-case node_modules and .git segments on Windows', {
-		skip: process.platform !== 'win32'
-	}, async () => {
-		const tempDir = createTempDir();
-		tempDirs.push(tempDir);
-		const included = path.join(tempDir, 'output', 'app.msix');
-		const dependency = path.join(tempDir, 'NODE_MODULES', 'pkg', 'ignored.msix');
-		const repositoryMetadata = path.join(tempDir, 'vendor', '.GIT', 'objects', 'ignored.appx');
-		createFile(included);
-		createFile(dependency);
-		createFile(repositoryMetadata);
-
-		const results = await findWorkspaceArtifacts(
-			tempDir,
-			createFinder([included, dependency, repositoryMetadata]),
-			ARTIFACT_GLOBS
-		);
-
-		assert.deepEqual(results, {
-			paths: [included],
-			sourceTruncated: false,
-			displayTruncated: false
-		});
-	});
-
-	it('does not start discovery when already aborted', async () => {
-		const controller = new AbortController();
-		controller.abort();
-		let called = false;
-
-		const results = await findWorkspaceArtifacts('C:\\workspace', async () => {
-			called = true;
-			return [];
-		}, ARTIFACT_GLOBS, controller.signal);
-
-		assert.deepEqual(results, { paths: [], sourceTruncated: false, displayTruncated: false });
-		assert.equal(called, false);
-	});
-
-	for (const cancellationErrorName of ['AbortError', 'Canceled', 'CancellationError']) {
-		it(`stops an in-progress discovery for ${cancellationErrorName}`, async () => {
-			const controller = new AbortController();
-			const finder: WorkspaceFileFinder = async (_include, signal) =>
-				new Promise((_resolve, reject) => {
-					signal?.addEventListener('abort', () => {
-						const error = new Error('The operation was aborted');
-						error.name = cancellationErrorName;
-						reject(error);
-					}, { once: true });
-				});
-
-			const discovery = findWorkspaceArtifacts('C:\\workspace', finder, ARTIFACT_GLOBS, controller.signal);
-			controller.abort();
-
-			assert.deepEqual(await discovery, {
-				paths: [],
-				sourceTruncated: false,
-				displayTruncated: false
-			});
-		});
-	}
-
-	it('stops stat collection between batches when aborted', async () => {
-		const tempDir = createTempDir();
-		tempDirs.push(tempDir);
-		const files = Array.from({ length: 101 }, (_, index) => path.join(tempDir, `${index}.msix`));
-		for (const file of files) {
-			createFile(file);
-		}
-
-		const controller = new AbortController();
-		const promisesFs = fs.promises as { stat: typeof fs.promises.stat };
-		const originalStat = promisesFs.stat;
-		let statCalls = 0;
-		promisesFs.stat = (async (targetPath: fs.PathLike) => {
-			statCalls++;
-			const result = await originalStat(targetPath);
-			controller.abort();
-			return result;
-		}) as typeof fs.promises.stat;
-
-		try {
-			const results = await findWorkspaceArtifacts(
-				tempDir,
-				createFinder(files),
-				ARTIFACT_GLOBS,
-				controller.signal
-			);
-			assert.deepEqual(results, { paths: [], sourceTruncated: false, displayTruncated: false });
-			assert.equal(statCalls, 100);
-		} finally {
-			promisesFs.stat = originalStat;
-		}
-	});
-
-	it('propagates non-abort discovery errors', async () => {
-		const expected = new Error('search failed');
-
-		await assert.rejects(
-			findWorkspaceArtifacts('C:\\workspace', async () => { throw expected; }, ARTIFACT_GLOBS),
-			expected
-		);
-	});
-
-	it('propagates an ordinary error raised after cancellation', async () => {
-		const controller = new AbortController();
-		const expected = new Error('search failed during cancellation');
-		const finder: WorkspaceFileFinder = async (_include, signal) =>
-			new Promise((_resolve, reject) => {
-				signal?.addEventListener('abort', () => reject(expected), { once: true });
-			});
-
-		const discovery = findWorkspaceArtifacts('C:\\workspace', finder, ARTIFACT_GLOBS, controller.signal);
-		controller.abort();
-
-		await assert.rejects(discovery, expected);
-	});
-
-	for (const cancellationErrorName of ['AbortError', 'Canceled', 'CancellationError']) {
-		it(`propagates ${cancellationErrorName} when the signal is not aborted`, async () => {
-			const expected = new Error('not actually cancelled');
-			expected.name = cancellationErrorName;
-
-			await assert.rejects(
-				findWorkspaceArtifacts('C:\\workspace', async () => { throw expected; }, ARTIFACT_GLOBS),
-				expected
-			);
-		});
-	}
-});
-
-describe('runWithCancellation', () => {
-	it('returns a successful operation result and disposes the listener', async () => {
-		const token = new ControlledCancellationToken();
-
-		const result = await runWithCancellation(token, async signal => {
-			assert.equal(signal.aborted, false);
-			return 'found';
-		});
-
-		assert.deepEqual(result, { cancelled: false, value: 'found' });
-		assert.equal(token.listenerCount, 0);
-		assert.equal(token.disposeCount, 1);
-	});
-
-	it('propagates an operation rejection and disposes the listener', async () => {
-		const token = new ControlledCancellationToken();
-		const expected = new Error('discovery failed');
-
-		await assert.rejects(
-			runWithCancellation(token, async () => { throw expected; }),
-			expected
-		);
-		assert.equal(token.listenerCount, 0);
-		assert.equal(token.disposeCount, 1);
-	});
-
-	it('propagates an ordinary rejection after cancellation and disposes the listener', async () => {
-		const token = new ControlledCancellationToken();
-		const expected = new Error('discovery failed during cancellation');
-		const operation = runWithCancellation(token, signal =>
-			new Promise<never>((_resolve, reject) => {
-				signal.addEventListener('abort', () => reject(expected), { once: true });
-			})
-		);
-
-		token.cancel();
-
-		await assert.rejects(operation, expected);
-		assert.equal(token.listenerCount, 0);
-		assert.equal(token.disposeCount, 1);
-	});
-
-	it('does not start the operation for a pre-cancelled token and disposes the listener', async () => {
-		const token = new ControlledCancellationToken();
-		token.cancel();
-		let operationCalled = false;
-
-		const result = await runWithCancellation(token, async () => {
-			operationCalled = true;
-			return ['unexpected'];
-		});
-
-		assert.deepEqual(result, { cancelled: true, value: undefined });
-		assert.equal(operationCalled, false);
-		assert.equal(token.listenerCount, 0);
-		assert.equal(token.disposeCount, 1);
-	});
-
-	it('aborts an in-progress finder and disposes the listener', async () => {
-		const token = new ControlledCancellationToken();
-		let finderObservedAbort = false;
-		const finder: WorkspaceFileFinder = async (_include, signal) =>
-			new Promise((_resolve, reject) => {
-				signal?.addEventListener('abort', () => {
-					finderObservedAbort = true;
-					const error = new Error('cancelled');
-					error.name = 'Canceled';
-					reject(error);
-				}, { once: true });
-			});
-
-		const discovery = runWithCancellation(token, signal =>
-			findWorkspaceArtifacts('C:\\workspace', finder, ARTIFACT_GLOBS, signal)
-		);
-		token.cancel();
-		const result = await discovery;
-
-		assert.equal(result.cancelled, true);
-		assert.deepEqual(result.value, {
-			paths: [],
-			sourceTruncated: false,
-			displayTruncated: false
-		});
-		assert.equal(finderObservedAbort, true);
-		assert.equal(token.listenerCount, 0);
-		assert.equal(token.disposeCount, 1);
-	});
-
-	it('returns a resolved value as cancelled when cancellation wins the race', async () => {
-		const token = new ControlledCancellationToken();
-		let resolveOperation!: (value: string) => void;
-		const operation = runWithCancellation(
-			token,
-			() => new Promise<string>(resolve => { resolveOperation = resolve; })
-		);
-
-		token.cancel();
-		resolveOperation('late value');
-
-		assert.deepEqual(await operation, { cancelled: true, value: 'late value' });
-		assert.equal(token.listenerCount, 0);
-		assert.equal(token.disposeCount, 1);
-	});
-});
-
-describe('runWithCancellationSource', () => {
-	function createTrackedSignal(): {
-		controller: AbortController;
-		addCount: () => number;
-		removeCount: () => number;
-	} {
-		const controller = new AbortController();
-		let adds = 0;
-		let removes = 0;
-		const signal = controller.signal;
-		const originalAdd = signal.addEventListener.bind(signal);
-		const originalRemove = signal.removeEventListener.bind(signal);
-		signal.addEventListener = ((...args: Parameters<AbortSignal['addEventListener']>) => {
-			adds++;
-			return originalAdd(...args);
-		}) as AbortSignal['addEventListener'];
-		signal.removeEventListener = ((...args: Parameters<AbortSignal['removeEventListener']>) => {
-			removes++;
-			return originalRemove(...args);
-		}) as AbortSignal['removeEventListener'];
-		return { controller, addCount: () => adds, removeCount: () => removes };
-	}
-
-	it('hands off the token and disposes the source and abort listener on success', async () => {
-		const tracked = createTrackedSignal();
-		let disposed = 0;
-		const token = { id: 'token' };
-
-		const result = await runWithCancellationSource(
-			tracked.controller.signal,
-			() => ({ token, cancel() {}, dispose() { disposed++; } }),
-			async receivedToken => {
-				assert.equal(receivedToken, token);
-				return ['found'];
-			}
-		);
-
-		assert.deepEqual(result, ['found']);
-		assert.equal(disposed, 1);
-		assert.equal(tracked.addCount(), 1);
-		assert.equal(tracked.removeCount(), 1);
-	});
-
-	it('propagates rejection while cleaning up exactly once', async () => {
-		const tracked = createTrackedSignal();
-		const expected = new Error('find failed');
-		let disposed = 0;
-
-		await assert.rejects(
-			runWithCancellationSource(
-				tracked.controller.signal,
-				() => ({ token: {}, cancel() {}, dispose() { disposed++; } }),
-				async () => { throw expected; }
-			),
-			expected
-		);
-		assert.equal(disposed, 1);
-		assert.equal(tracked.removeCount(), 1);
-	});
-
-	it('propagates abort to the source and removes the listener', async () => {
-		const tracked = createTrackedSignal();
-		let cancelled = 0;
-		let disposed = 0;
-		let finish!: () => void;
-		const pending = runWithCancellationSource(
-			tracked.controller.signal,
-			() => ({ token: {}, cancel() { cancelled++; }, dispose() { disposed++; } }),
-			() => new Promise<void>(resolve => { finish = resolve; })
-		);
-
-		tracked.controller.abort();
-		finish();
-		await pending;
-
-		assert.equal(cancelled, 1);
-		assert.equal(disposed, 1);
-		assert.equal(tracked.removeCount(), 1);
-	});
-
-	it('cancels a pre-aborted source without installing a listener', async () => {
-		const tracked = createTrackedSignal();
-		tracked.controller.abort();
-		let cancelled = 0;
-		let disposed = 0;
-
-		await runWithCancellationSource(
-			tracked.controller.signal,
-			() => ({ token: {}, cancel() { cancelled++; }, dispose() { disposed++; } }),
-			async () => undefined
-		);
-
-		assert.equal(cancelled, 1);
-		assert.equal(disposed, 1);
-		assert.equal(tracked.addCount(), 0);
-		assert.equal(tracked.removeCount(), 0);
-	});
-});
-
-describe('discoverSignFilesWithFallback', () => {
-	for (const [context, pathName] of [
-		['signable artifacts', 'app.msix'],
-		['signing certificates', 'dev.pfx']
-	] as const) {
-		it(`hands off discovered ${context}`, async () => {
-			const value = {
-				paths: [`C:\\out\\${pathName}`],
-				sourceTruncated: false,
-				displayTruncated: false
-			};
-			const result = await discoverSignFilesWithFallback(
-				context,
-				async () => ({ cancelled: false, value }),
-				async () => { throw new Error('warning should not be shown'); }
-			);
-			assert.deepEqual(result, { cancelled: false, result: value });
-		});
-	}
-
-	it('preserves truncation metadata from workspace discovery', async () => {
-		const value = {
-			paths: ['C:\\out\\app.msix'],
-			sourceTruncated: true,
-			displayTruncated: false
-		};
-
-		const result = await discoverSignFilesWithFallback(
-			'signable artifacts',
-			async () => ({ cancelled: false, value }),
-			async () => { throw new Error('warning should not be shown'); }
-		);
-
-		assert.deepEqual(result, { cancelled: false, result: value });
-	});
-
-	it('includes failure context and requests Browse when selected', async () => {
-		let warning = '';
-		const result = await discoverSignFilesWithFallback(
-			'signable artifacts',
-			async () => { throw new Error('search unavailable'); },
-			async message => {
-				warning = message;
-				return 'Browse…';
-			}
-		);
-
-		assert.match(warning, /signable artifacts: search unavailable/);
-		assert.deepEqual(result, { cancelled: false, browseRequested: true });
-	});
-
-	it('does not request Browse when the warning is dismissed', async () => {
-		const result = await discoverSignFilesWithFallback(
-			'signing certificates',
-			async () => { throw new Error('search unavailable'); },
-			async () => undefined
-		);
-		assert.deepEqual(result, { cancelled: false, browseRequested: false });
-	});
-
-	it('bypasses the warning when discovery is cancelled', async () => {
-		let warningShown = false;
-		const result = await discoverSignFilesWithFallback(
-			'signable artifacts',
-			async () => ({
-				cancelled: true,
-				value: { paths: [], sourceTruncated: false, displayTruncated: false }
-			}),
-			async () => {
-				warningShown = true;
-				return 'Browse…';
-			}
-		);
-		assert.deepEqual(result, {
-			cancelled: true,
-			result: { paths: [], sourceTruncated: false, displayTruncated: false }
-		});
-		assert.equal(warningShown, false);
-	});
-});
-
-describe('handoffSignFileDiscovery', () => {
-	it('invokes manual selection once for a direct empty discovery and returns its result', async () => {
-		let calls = 0;
-		const result = await handoffSignFileDiscovery(
-			{
-				cancelled: false,
-				result: { paths: [], sourceTruncated: false, displayTruncated: false }
-			},
-			async () => {
-				calls++;
-				return 'C:\\manual\\app.msix';
-			}
-		);
-
-		assert.equal(result, 'C:\\manual\\app.msix');
-		assert.equal(calls, 1);
-	});
-
-	it('does not invoke manual selection when a truncated empty discovery warning is dismissed', async () => {
-		let calls = 0;
-		let warning = '';
-		const result = await handoffSignFileDiscovery(
-			{
-				cancelled: false,
-				result: { paths: [], sourceTruncated: true, displayTruncated: false }
-			},
-			async () => {
-				calls++;
-				return 'unexpected';
-			},
-			{
-				searchContext: 'signing certificates',
-				showWarning: async message => {
-					warning = message;
-					return undefined;
-				}
-			}
-		);
-
-		assert.equal(result, undefined);
-		assert.equal(calls, 0);
-		assert.match(warning, /first 500 workspace matches/i);
-		assert.match(warning, /signing certificates/i);
-	});
-
-	for (const [kind, manualPath] of [
-		['artifact', 'C:\\manual\\app.msix'],
-		['certificate', 'C:\\manual\\cert.pfx']
-	] as const) {
-		it(`invokes the ${kind} manual selector once when Browse was requested`, async () => {
-			let calls = 0;
-			const result = await handoffSignFileDiscovery(
-				{ cancelled: false, browseRequested: true },
-				async () => {
-					calls++;
-					return manualPath;
-				}
-			);
-
-			assert.equal(result, manualPath);
-			assert.equal(calls, 1);
-		});
-	}
-
-	for (const discovery of [
-		{
-			cancelled: true,
-			result: { paths: [], sourceTruncated: false, displayTruncated: false }
-		},
-		{ cancelled: false, browseRequested: false }
-	]) {
-		it(`does not invoke manual selection for ${discovery.cancelled ? 'cancellation' : 'dismissal'}`, async () => {
-			let calls = 0;
-			const result = await handoffSignFileDiscovery(discovery, async () => {
-				calls++;
-				return 'unexpected';
-			});
-
-			assert.equal(result, undefined);
-			assert.equal(calls, 0);
-		});
-	}
-
-	it('continues with normal discovered paths without invoking manual selection', async () => {
-		const discovered = {
-			paths: ['C:\\out\\app.msix'],
-			sourceTruncated: true,
-			displayTruncated: false
-		};
-		let calls = 0;
-
-		const result = await handoffSignFileDiscovery(
-			{ cancelled: false, result: discovered },
-			async () => {
-				calls++;
-				return 'unexpected';
-			}
-		);
-
-		assert.equal(result, discovered);
-		assert.equal(calls, 0);
-	});
-});
-
-describe('coordinateWorkspaceSignFileSelection', () => {
-	it('shows discovered workspace items plus a partial-results Browse option', async () => {
-		const discovery = {
-			cancelled: false,
-			result: {
-				paths: ['C:\\workspace\\output\\app.msix'],
-				sourceTruncated: true,
-				displayTruncated: false
-			}
-		};
-		let warningShown = false;
-		let manualCalls = 0;
-		let quickPickItems: Array<{ label: string; description?: string; detail: string }> = [];
-
-		const result = await coordinateWorkspaceSignFileSelection('C:\\workspace', discovery, {
-			searchContext: 'signable artifacts',
-			placeHolder: 'Select a package to sign',
-			selectManualFile: async () => {
-				manualCalls++;
-				return 'C:\\manual\\fallback.msix';
-			},
-			showWarning: async () => {
-				warningShown = true;
-				return 'Browse…';
-			},
-			showQuickPick: async items => {
-				quickPickItems = [...items];
-				return items[1];
-			}
-		});
-
-		assert.equal(result, 'C:\\manual\\fallback.msix');
-		assert.equal(warningShown, false);
-		assert.equal(manualCalls, 1);
-		assert.deepEqual(quickPickItems[0], createWorkspaceSignFileQuickPickItem('C:\\workspace', 'C:\\workspace\\output\\app.msix'));
-		assert.match(quickPickItems[1].label, /browse/i);
-		assert.match(quickPickItems[1].detail, /first 500 workspace matches/i);
-		assert.match(quickPickItems[1].detail, /browse to choose a different file manually/i);
-	});
-
-	it('surfaces an explicit warning before manual Browse when bounded discovery yields no displayable paths', async () => {
-		let warning = '';
-		let quickPickCalls = 0;
-		let manualCalls = 0;
-
-		const result = await coordinateWorkspaceSignFileSelection('C:\\workspace', {
-			cancelled: false,
-			result: {
-				paths: [],
-				sourceTruncated: true,
-				displayTruncated: false
-			}
-		}, {
-			searchContext: 'signable artifacts',
-			placeHolder: 'Select a package to sign',
-			selectManualFile: async () => {
-				manualCalls++;
-				return 'C:\\manual\\bounded.msix';
-			},
-			showWarning: async message => {
-				warning = message;
-				return 'Browse…';
-			},
-			showQuickPick: async () => {
-				quickPickCalls++;
-				return undefined;
-			}
-		});
-
-		assert.equal(result, 'C:\\manual\\bounded.msix');
-		assert.equal(quickPickCalls, 0);
-		assert.equal(manualCalls, 1);
-		assert.match(warning, /first 500 workspace matches/i);
-		assert.match(warning, /signable artifacts/i);
-		assert.match(warning, /additional matching files may still exist/i);
-	});
-});
-
-describe('createSignBrowseItem', () => {
-	it('discloses when source discovery and the displayed list are truncated', () => {
-		const item = createSignBrowseItem({ sourceTruncated: true, displayTruncated: true });
-
-		assert.match(item.label, /more files available/i);
-		assert.match(item.detail, /newest 100 of the first 500/i);
-		assert.match(item.detail, /additional workspace matches may exist/i);
-		assert.match(item.detail, /browse to choose a different file manually/i);
-	});
-
-	it('discloses when only the displayed list is truncated', () => {
-		const item = createSignBrowseItem({ sourceTruncated: false, displayTruncated: true });
-
-		assert.match(item.label, /more files available/i);
-		assert.match(item.detail, /newest 100 matching files/i);
-		assert.match(item.detail, /browse to choose a different file manually/i);
-	});
-
-	it('discloses when only source discovery is truncated', () => {
-		const item = createSignBrowseItem({ sourceTruncated: true, displayTruncated: false });
-
-		assert.match(item.label, /additional files may exist/i);
-		assert.match(item.detail, /first 500 workspace matches/i);
-		assert.match(item.detail, /browse to choose a different file manually/i);
-	});
-
-	it('uses the normal Browse wording for complete discovery', () => {
-		assert.deepEqual(
-			createSignBrowseItem({ sourceTruncated: false, displayTruncated: false }),
-			{ label: '$(folder-opened) Browse…', detail: 'Open a file picker' }
-		);
+		assert.deepEqual(results, [included]);
 	});
 });
 
@@ -1027,14 +129,10 @@ describe('findWorkspaceArtifacts with CERTIFICATE_GLOBS', () => {
 		createFile(path.join(tempDir, 'devcert.pfx'));
 		createFile(path.join(tempDir, 'certs', 'prod.pfx'));
 
-		const results = await findWorkspaceArtifacts(
-			tempDir,
-			createFinder([path.join(tempDir, 'devcert.pfx'), path.join(tempDir, 'certs', 'prod.pfx')]),
-			CERTIFICATE_GLOBS
-		);
+		const results = await findWorkspaceArtifacts(tempDir, CERTIFICATE_GLOBS);
 
 		assert.deepEqual(
-			results.paths.map(filePath => path.basename(filePath)).sort(),
+			results.map(filePath => path.basename(filePath)).sort(),
 			['devcert.pfx', 'prod.pfx']
 		);
 	});
@@ -1045,21 +143,21 @@ describe('findWorkspaceArtifacts with CERTIFICATE_GLOBS', () => {
 		createFile(path.join(tempDir, 'app.msix'));
 		createFile(path.join(tempDir, 'cert.pem'));
 
-		const results = await findWorkspaceArtifacts(tempDir, createFinder([]), CERTIFICATE_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, CERTIFICATE_GLOBS);
 
-		assert.deepEqual(results, { paths: [], sourceTruncated: false, displayTruncated: false });
+		assert.deepEqual(results, []);
 	});
 
-	it('uses the certificate glob without a brace wrapper', async () => {
-		const finder: WorkspaceFileFinder = async (includePattern) => {
-			assert.equal(includePattern, '**/*.pfx');
-			return [];
-		};
+	it('excludes node_modules certificates', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const included = path.join(tempDir, 'devcert.pfx');
+		createFile(included);
+		createFile(path.join(tempDir, 'node_modules', 'pkg', 'test.pfx'));
 
-		assert.deepEqual(
-			await findWorkspaceArtifacts('C:\\workspace', finder, CERTIFICATE_GLOBS),
-			{ paths: [], sourceTruncated: false, displayTruncated: false }
-		);
+		const results = await findWorkspaceArtifacts(tempDir, CERTIFICATE_GLOBS);
+
+		assert.deepEqual(results, [included]);
 	});
 });
 

--- a/src/test/sign-utils.test.ts
+++ b/src/test/sign-utils.test.ts
@@ -3,7 +3,22 @@ import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { findWorkspaceArtifacts, buildSignCommand, CERTIFICATE_GLOBS } from '../sign-utils';
+import {
+	findWorkspaceArtifacts,
+	buildSignCommand,
+	coordinateWorkspaceSignFileSelection,
+	CERTIFICATE_GLOBS,
+	createSignBrowseItem,
+	createWorkspaceSignFileQuickPickItem,
+	discoverSignFilesWithFallback,
+	handoffSignFileDiscovery,
+	runWithCancellation,
+	runWithCancellationSource,
+	WORKSPACE_ARTIFACT_MAX_RESULTS,
+	WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT,
+	type CancellationTokenLike,
+	type WorkspaceFileFinder
+} from '../sign-utils';
 import { ARTIFACT_GLOBS } from '../artifact-types';
 
 function createTempDir(): string {
@@ -20,6 +35,37 @@ function createFile(filePath: string, mtimeMs?: number): void {
 	if (mtimeMs !== undefined) {
 		const time = new Date(mtimeMs);
 		fs.utimesSync(filePath, time, time);
+	}
+}
+
+function createFinder(results: string[]): WorkspaceFileFinder {
+	return async () => results;
+}
+
+class ControlledCancellationToken implements CancellationTokenLike {
+	isCancellationRequested = false;
+	disposeCount = 0;
+	private readonly listeners = new Set<() => void>();
+
+	onCancellationRequested(listener: () => void): { dispose(): void } {
+		this.listeners.add(listener);
+		return {
+			dispose: () => {
+				this.disposeCount++;
+				this.listeners.delete(listener);
+			}
+		};
+	}
+
+	cancel(): void {
+		this.isCancellationRequested = true;
+		for (const listener of this.listeners) {
+			listener();
+		}
+	}
+
+	get listenerCount(): number {
+		return this.listeners.size;
 	}
 }
 
@@ -40,10 +86,16 @@ describe('findWorkspaceArtifacts', () => {
 		createFile(path.join(tempDir, 'c.appx'));
 		createFile(path.join(tempDir, 'd.appxbundle'));
 
-		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
+		const files = [
+			path.join(tempDir, 'a.msix'),
+			path.join(tempDir, 'b.msixbundle'),
+			path.join(tempDir, 'c.appx'),
+			path.join(tempDir, 'd.appxbundle')
+		];
+		const results = await findWorkspaceArtifacts(tempDir, createFinder(files), ARTIFACT_GLOBS);
 
 		assert.deepEqual(
-			results.map(filePath => path.basename(filePath)).sort(),
+			results.paths.map(filePath => path.basename(filePath)).sort(),
 			['a.msix', 'b.msixbundle', 'c.appx', 'd.appxbundle']
 		);
 	});
@@ -58,9 +110,165 @@ describe('findWorkspaceArtifacts', () => {
 		createFile(newest, 1_700_000_000_200);
 		createFile(middle, 1_700_000_000_100);
 
-		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, createFinder([older, newest, middle]), ARTIFACT_GLOBS);
 
-		assert.deepEqual(results, [newest, middle, older]);
+		assert.deepEqual(results, {
+			paths: [newest, middle, older],
+			sourceTruncated: false,
+			displayTruncated: false
+		});
+	});
+
+	it('does not report display truncation for exactly 100 valid candidates', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const files = Array.from(
+			{ length: WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT },
+			(_, index) => path.join(tempDir, `${index}.msix`)
+		);
+		for (const [index, file] of files.entries()) {
+			createFile(file, 1_700_000_000_000 + index);
+		}
+
+		const results = await findWorkspaceArtifacts(tempDir, createFinder(files), ARTIFACT_GLOBS);
+
+		assert.equal(results.paths.length, WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT);
+		assert.equal(results.paths[0], files.at(-1));
+		assert.equal(results.paths.at(-1), files[0]);
+		assert.equal(results.sourceTruncated, false);
+		assert.equal(results.displayTruncated, false);
+	});
+
+	it('reports display truncation for exactly 101 valid candidates and keeps the newest 100', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const files = Array.from(
+			{ length: WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT + 1 },
+			(_, index) => path.join(tempDir, `${index}.msix`)
+		);
+		for (const [index, file] of files.entries()) {
+			createFile(file, 1_700_000_000_000 + index);
+		}
+		const newest = files.at(-1)!;
+
+		const results = await findWorkspaceArtifacts(tempDir, createFinder(files), ARTIFACT_GLOBS);
+
+		assert.equal(results.paths.length, WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT);
+		assert.equal(results.paths[0], newest);
+		assert.ok(results.paths.includes(newest));
+		assert.equal(results.sourceTruncated, false);
+		assert.equal(results.displayTruncated, true);
+	});
+
+	it('does not report source truncation for exactly 500 source candidates', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const files = Array.from(
+			{ length: WORKSPACE_ARTIFACT_MAX_RESULTS },
+			(_, index) => path.join(tempDir, `${index}.msix`)
+		);
+		for (const [index, file] of files.entries()) {
+			createFile(file, 1_700_000_000_000 + index);
+		}
+
+		const result = await findWorkspaceArtifacts(tempDir, createFinder(files), ARTIFACT_GLOBS);
+
+		assert.equal(result.sourceTruncated, false);
+		assert.equal(result.displayTruncated, true);
+		assert.equal(result.paths.length, WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT);
+		assert.equal(result.paths[0], files[WORKSPACE_ARTIFACT_MAX_RESULTS - 1]);
+		assert.equal(result.paths.at(-1), files[WORKSPACE_ARTIFACT_MAX_RESULTS - WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT]);
+	});
+
+	it('requests one extra candidate and reports truncation for exactly 501 source candidates while processing only 500', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const files = Array.from(
+			{ length: WORKSPACE_ARTIFACT_MAX_RESULTS + 1 },
+			(_, index) => path.join(tempDir, `${index}.msix`)
+		);
+		for (const [index, file] of files.entries()) {
+			createFile(file, 1_700_000_000_000 + index);
+		}
+
+		const result = await findWorkspaceArtifacts(tempDir, createFinder(files), ARTIFACT_GLOBS);
+
+		assert.equal(result.sourceTruncated, true);
+		assert.equal(result.displayTruncated, true);
+		assert.equal(result.paths.length, WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT);
+		assert.ok(!result.paths.includes(files.at(-1)!));
+		assert.equal(result.paths[0], files[WORKSPACE_ARTIFACT_MAX_RESULTS - 1]);
+	});
+
+	it('warns before manual selection when all 501 source candidates are post-filtered', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const files = Array.from(
+			{ length: WORKSPACE_ARTIFACT_MAX_RESULTS + 1 },
+			(_, index) => path.join(tempDir, 'node_modules', `${index}.msix`)
+		);
+
+		const discovery = await findWorkspaceArtifacts(tempDir, createFinder(files), ARTIFACT_GLOBS);
+
+		assert.deepEqual(discovery, {
+			paths: [],
+			sourceTruncated: true,
+			displayTruncated: false
+		});
+
+		let warning = '';
+		let manualCalls = 0;
+		const result = await handoffSignFileDiscovery(
+			{ cancelled: false, result: discovery },
+			async () => {
+				manualCalls++;
+				return 'C:\\manual\\app.msix';
+			},
+			{
+				searchContext: 'signable artifacts',
+				showWarning: async message => {
+					warning = message;
+					return 'Browse…';
+				}
+			}
+		);
+		assert.match(warning, /first 500 workspace matches/i);
+		assert.match(warning, /signable artifacts/i);
+		assert.match(warning, /additional matching files may still exist/i);
+		assert.equal(result, 'C:\\manual\\app.msix');
+		assert.equal(manualCalls, 1);
+	});
+
+	it('offers a clearly labeled Browse path when valid paths remain after source truncation', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const excluded = Array.from(
+			{ length: WORKSPACE_ARTIFACT_MAX_RESULTS - 2 },
+			(_, index) => path.join(tempDir, 'node_modules', `${index}.msix`)
+		);
+		const valid = [
+			path.join(tempDir, 'output', 'app.msix'),
+			path.join(tempDir, 'output', 'app.appx')
+		];
+		const uninspected = path.join(tempDir, 'output', 'uninspected.msix');
+		for (const file of valid) {
+			createFile(file);
+		}
+
+		const discovery = await findWorkspaceArtifacts(
+			tempDir,
+			createFinder([...excluded, ...valid, uninspected]),
+			ARTIFACT_GLOBS
+		);
+
+		assert.deepEqual(discovery, {
+			paths: valid,
+			sourceTruncated: true,
+			displayTruncated: false
+		});
+		const browseItem = createSignBrowseItem(discovery);
+		assert.match(browseItem.label, /browse/i);
+		assert.match(browseItem.label, /additional files may exist/i);
 	});
 
 	it('tolerates stat failures by pushing those files to the end', async () => {
@@ -81,8 +289,12 @@ describe('findWorkspaceArtifacts', () => {
 		}) as typeof fs.promises.stat;
 
 		try {
-			const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
-			assert.deepEqual(results, [stable, missing]);
+			const results = await findWorkspaceArtifacts(tempDir, createFinder([stable, missing]), ARTIFACT_GLOBS);
+			assert.deepEqual(results, {
+				paths: [stable, missing],
+				sourceTruncated: false,
+				displayTruncated: false
+			});
 		} finally {
 			promisesFs.stat = originalStat;
 		}
@@ -92,9 +304,9 @@ describe('findWorkspaceArtifacts', () => {
 		const tempDir = createTempDir();
 		tempDirs.push(tempDir);
 
-		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, createFinder([]), ARTIFACT_GLOBS);
 
-		assert.deepEqual(results, []);
+		assert.deepEqual(results, { paths: [], sourceTruncated: false, displayTruncated: false });
 	});
 
 	it('discovers files in subdirectories', async () => {
@@ -103,22 +315,708 @@ describe('findWorkspaceArtifacts', () => {
 		const nested = path.join(tempDir, 'artifacts', 'release', 'app.msix');
 		createFile(nested);
 
-		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, createFinder([nested]), ARTIFACT_GLOBS);
 
-		assert.deepEqual(results, [nested]);
+		assert.deepEqual(results, {
+			paths: [nested],
+			sourceTruncated: false,
+			displayTruncated: false
+		});
 	});
 
-	it('excludes node_modules and .git directories', async () => {
+	it('uses one brace-pattern search', async () => {
+		let callCount = 0;
+		const finder: WorkspaceFileFinder = async (includePattern, _signal, maxResults) => {
+			callCount++;
+			assert.equal(includePattern, '{**/*.msix,**/*.msixbundle,**/*.appx,**/*.appxbundle}');
+			assert.equal(maxResults, WORKSPACE_ARTIFACT_MAX_RESULTS + 1);
+			return [];
+		};
+
+		await findWorkspaceArtifacts('C:\\workspace', finder, ARTIFACT_GLOBS);
+
+		assert.equal(callCount, 1);
+	});
+
+	it('filters ignored matches before capping results for the QuickPick', async () => {
 		const tempDir = createTempDir();
 		tempDirs.push(tempDir);
-		const included = path.join(tempDir, 'out', 'app.msix');
+		const ignored = Array.from(
+			{ length: WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT },
+			(_, index) => path.join(tempDir, 'node_modules', `${index}.msix`)
+		);
+		const valid = Array.from(
+			{ length: WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT + 1 },
+			(_, index) => path.join(tempDir, 'output', `${index}.msix`)
+		);
+		for (const file of [...ignored, ...valid]) {
+			createFile(file);
+		}
+
+		const results = await findWorkspaceArtifacts(
+			tempDir,
+			createFinder([...ignored, ...valid]),
+			ARTIFACT_GLOBS
+		);
+
+		assert.equal(results.paths.length, WORKSPACE_ARTIFACT_QUICK_PICK_LIMIT);
+		assert.ok(results.paths.every(file => file.includes(`${path.sep}output${path.sep}`)));
+		assert.equal(results.sourceTruncated, false);
+		assert.equal(results.displayTruncated, true);
+	});
+
+	it('excludes node_modules and .git results without applying user file exclusions', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const included = path.join(tempDir, 'AppPackages', 'app.msix');
+		const dependency = path.join(tempDir, 'node_modules', 'pkg', 'ignored.msix');
+		const repositoryMetadata = path.join(tempDir, 'vendor', '.git', 'objects', 'ignored.appx');
 		createFile(included);
-		createFile(path.join(tempDir, 'node_modules', 'pkg', 'ignored.msix'));
-		createFile(path.join(tempDir, '.git', 'objects', 'ignored.appx'));
+		createFile(dependency);
+		createFile(repositoryMetadata);
 
-		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
+		const results = await findWorkspaceArtifacts(
+			tempDir,
+			createFinder([included, dependency, repositoryMetadata]),
+			ARTIFACT_GLOBS
+		);
 
-		assert.deepEqual(results, [included]);
+		assert.deepEqual(results, {
+			paths: [included],
+			sourceTruncated: false,
+			displayTruncated: false
+		});
+	});
+
+	it('excludes mixed-case node_modules and .git segments on Windows', {
+		skip: process.platform !== 'win32'
+	}, async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const included = path.join(tempDir, 'output', 'app.msix');
+		const dependency = path.join(tempDir, 'NODE_MODULES', 'pkg', 'ignored.msix');
+		const repositoryMetadata = path.join(tempDir, 'vendor', '.GIT', 'objects', 'ignored.appx');
+		createFile(included);
+		createFile(dependency);
+		createFile(repositoryMetadata);
+
+		const results = await findWorkspaceArtifacts(
+			tempDir,
+			createFinder([included, dependency, repositoryMetadata]),
+			ARTIFACT_GLOBS
+		);
+
+		assert.deepEqual(results, {
+			paths: [included],
+			sourceTruncated: false,
+			displayTruncated: false
+		});
+	});
+
+	it('does not start discovery when already aborted', async () => {
+		const controller = new AbortController();
+		controller.abort();
+		let called = false;
+
+		const results = await findWorkspaceArtifacts('C:\\workspace', async () => {
+			called = true;
+			return [];
+		}, ARTIFACT_GLOBS, controller.signal);
+
+		assert.deepEqual(results, { paths: [], sourceTruncated: false, displayTruncated: false });
+		assert.equal(called, false);
+	});
+
+	for (const cancellationErrorName of ['AbortError', 'Canceled', 'CancellationError']) {
+		it(`stops an in-progress discovery for ${cancellationErrorName}`, async () => {
+			const controller = new AbortController();
+			const finder: WorkspaceFileFinder = async (_include, signal) =>
+				new Promise((_resolve, reject) => {
+					signal?.addEventListener('abort', () => {
+						const error = new Error('The operation was aborted');
+						error.name = cancellationErrorName;
+						reject(error);
+					}, { once: true });
+				});
+
+			const discovery = findWorkspaceArtifacts('C:\\workspace', finder, ARTIFACT_GLOBS, controller.signal);
+			controller.abort();
+
+			assert.deepEqual(await discovery, {
+				paths: [],
+				sourceTruncated: false,
+				displayTruncated: false
+			});
+		});
+	}
+
+	it('stops stat collection between batches when aborted', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const files = Array.from({ length: 101 }, (_, index) => path.join(tempDir, `${index}.msix`));
+		for (const file of files) {
+			createFile(file);
+		}
+
+		const controller = new AbortController();
+		const promisesFs = fs.promises as { stat: typeof fs.promises.stat };
+		const originalStat = promisesFs.stat;
+		let statCalls = 0;
+		promisesFs.stat = (async (targetPath: fs.PathLike) => {
+			statCalls++;
+			const result = await originalStat(targetPath);
+			controller.abort();
+			return result;
+		}) as typeof fs.promises.stat;
+
+		try {
+			const results = await findWorkspaceArtifacts(
+				tempDir,
+				createFinder(files),
+				ARTIFACT_GLOBS,
+				controller.signal
+			);
+			assert.deepEqual(results, { paths: [], sourceTruncated: false, displayTruncated: false });
+			assert.equal(statCalls, 100);
+		} finally {
+			promisesFs.stat = originalStat;
+		}
+	});
+
+	it('propagates non-abort discovery errors', async () => {
+		const expected = new Error('search failed');
+
+		await assert.rejects(
+			findWorkspaceArtifacts('C:\\workspace', async () => { throw expected; }, ARTIFACT_GLOBS),
+			expected
+		);
+	});
+
+	it('propagates an ordinary error raised after cancellation', async () => {
+		const controller = new AbortController();
+		const expected = new Error('search failed during cancellation');
+		const finder: WorkspaceFileFinder = async (_include, signal) =>
+			new Promise((_resolve, reject) => {
+				signal?.addEventListener('abort', () => reject(expected), { once: true });
+			});
+
+		const discovery = findWorkspaceArtifacts('C:\\workspace', finder, ARTIFACT_GLOBS, controller.signal);
+		controller.abort();
+
+		await assert.rejects(discovery, expected);
+	});
+
+	for (const cancellationErrorName of ['AbortError', 'Canceled', 'CancellationError']) {
+		it(`propagates ${cancellationErrorName} when the signal is not aborted`, async () => {
+			const expected = new Error('not actually cancelled');
+			expected.name = cancellationErrorName;
+
+			await assert.rejects(
+				findWorkspaceArtifacts('C:\\workspace', async () => { throw expected; }, ARTIFACT_GLOBS),
+				expected
+			);
+		});
+	}
+});
+
+describe('runWithCancellation', () => {
+	it('returns a successful operation result and disposes the listener', async () => {
+		const token = new ControlledCancellationToken();
+
+		const result = await runWithCancellation(token, async signal => {
+			assert.equal(signal.aborted, false);
+			return 'found';
+		});
+
+		assert.deepEqual(result, { cancelled: false, value: 'found' });
+		assert.equal(token.listenerCount, 0);
+		assert.equal(token.disposeCount, 1);
+	});
+
+	it('propagates an operation rejection and disposes the listener', async () => {
+		const token = new ControlledCancellationToken();
+		const expected = new Error('discovery failed');
+
+		await assert.rejects(
+			runWithCancellation(token, async () => { throw expected; }),
+			expected
+		);
+		assert.equal(token.listenerCount, 0);
+		assert.equal(token.disposeCount, 1);
+	});
+
+	it('propagates an ordinary rejection after cancellation and disposes the listener', async () => {
+		const token = new ControlledCancellationToken();
+		const expected = new Error('discovery failed during cancellation');
+		const operation = runWithCancellation(token, signal =>
+			new Promise<never>((_resolve, reject) => {
+				signal.addEventListener('abort', () => reject(expected), { once: true });
+			})
+		);
+
+		token.cancel();
+
+		await assert.rejects(operation, expected);
+		assert.equal(token.listenerCount, 0);
+		assert.equal(token.disposeCount, 1);
+	});
+
+	it('does not start the operation for a pre-cancelled token and disposes the listener', async () => {
+		const token = new ControlledCancellationToken();
+		token.cancel();
+		let operationCalled = false;
+
+		const result = await runWithCancellation(token, async () => {
+			operationCalled = true;
+			return ['unexpected'];
+		});
+
+		assert.deepEqual(result, { cancelled: true, value: undefined });
+		assert.equal(operationCalled, false);
+		assert.equal(token.listenerCount, 0);
+		assert.equal(token.disposeCount, 1);
+	});
+
+	it('aborts an in-progress finder and disposes the listener', async () => {
+		const token = new ControlledCancellationToken();
+		let finderObservedAbort = false;
+		const finder: WorkspaceFileFinder = async (_include, signal) =>
+			new Promise((_resolve, reject) => {
+				signal?.addEventListener('abort', () => {
+					finderObservedAbort = true;
+					const error = new Error('cancelled');
+					error.name = 'Canceled';
+					reject(error);
+				}, { once: true });
+			});
+
+		const discovery = runWithCancellation(token, signal =>
+			findWorkspaceArtifacts('C:\\workspace', finder, ARTIFACT_GLOBS, signal)
+		);
+		token.cancel();
+		const result = await discovery;
+
+		assert.equal(result.cancelled, true);
+		assert.deepEqual(result.value, {
+			paths: [],
+			sourceTruncated: false,
+			displayTruncated: false
+		});
+		assert.equal(finderObservedAbort, true);
+		assert.equal(token.listenerCount, 0);
+		assert.equal(token.disposeCount, 1);
+	});
+
+	it('returns a resolved value as cancelled when cancellation wins the race', async () => {
+		const token = new ControlledCancellationToken();
+		let resolveOperation!: (value: string) => void;
+		const operation = runWithCancellation(
+			token,
+			() => new Promise<string>(resolve => { resolveOperation = resolve; })
+		);
+
+		token.cancel();
+		resolveOperation('late value');
+
+		assert.deepEqual(await operation, { cancelled: true, value: 'late value' });
+		assert.equal(token.listenerCount, 0);
+		assert.equal(token.disposeCount, 1);
+	});
+});
+
+describe('runWithCancellationSource', () => {
+	function createTrackedSignal(): {
+		controller: AbortController;
+		addCount: () => number;
+		removeCount: () => number;
+	} {
+		const controller = new AbortController();
+		let adds = 0;
+		let removes = 0;
+		const signal = controller.signal;
+		const originalAdd = signal.addEventListener.bind(signal);
+		const originalRemove = signal.removeEventListener.bind(signal);
+		signal.addEventListener = ((...args: Parameters<AbortSignal['addEventListener']>) => {
+			adds++;
+			return originalAdd(...args);
+		}) as AbortSignal['addEventListener'];
+		signal.removeEventListener = ((...args: Parameters<AbortSignal['removeEventListener']>) => {
+			removes++;
+			return originalRemove(...args);
+		}) as AbortSignal['removeEventListener'];
+		return { controller, addCount: () => adds, removeCount: () => removes };
+	}
+
+	it('hands off the token and disposes the source and abort listener on success', async () => {
+		const tracked = createTrackedSignal();
+		let disposed = 0;
+		const token = { id: 'token' };
+
+		const result = await runWithCancellationSource(
+			tracked.controller.signal,
+			() => ({ token, cancel() {}, dispose() { disposed++; } }),
+			async receivedToken => {
+				assert.equal(receivedToken, token);
+				return ['found'];
+			}
+		);
+
+		assert.deepEqual(result, ['found']);
+		assert.equal(disposed, 1);
+		assert.equal(tracked.addCount(), 1);
+		assert.equal(tracked.removeCount(), 1);
+	});
+
+	it('propagates rejection while cleaning up exactly once', async () => {
+		const tracked = createTrackedSignal();
+		const expected = new Error('find failed');
+		let disposed = 0;
+
+		await assert.rejects(
+			runWithCancellationSource(
+				tracked.controller.signal,
+				() => ({ token: {}, cancel() {}, dispose() { disposed++; } }),
+				async () => { throw expected; }
+			),
+			expected
+		);
+		assert.equal(disposed, 1);
+		assert.equal(tracked.removeCount(), 1);
+	});
+
+	it('propagates abort to the source and removes the listener', async () => {
+		const tracked = createTrackedSignal();
+		let cancelled = 0;
+		let disposed = 0;
+		let finish!: () => void;
+		const pending = runWithCancellationSource(
+			tracked.controller.signal,
+			() => ({ token: {}, cancel() { cancelled++; }, dispose() { disposed++; } }),
+			() => new Promise<void>(resolve => { finish = resolve; })
+		);
+
+		tracked.controller.abort();
+		finish();
+		await pending;
+
+		assert.equal(cancelled, 1);
+		assert.equal(disposed, 1);
+		assert.equal(tracked.removeCount(), 1);
+	});
+
+	it('cancels a pre-aborted source without installing a listener', async () => {
+		const tracked = createTrackedSignal();
+		tracked.controller.abort();
+		let cancelled = 0;
+		let disposed = 0;
+
+		await runWithCancellationSource(
+			tracked.controller.signal,
+			() => ({ token: {}, cancel() { cancelled++; }, dispose() { disposed++; } }),
+			async () => undefined
+		);
+
+		assert.equal(cancelled, 1);
+		assert.equal(disposed, 1);
+		assert.equal(tracked.addCount(), 0);
+		assert.equal(tracked.removeCount(), 0);
+	});
+});
+
+describe('discoverSignFilesWithFallback', () => {
+	for (const [context, pathName] of [
+		['signable artifacts', 'app.msix'],
+		['signing certificates', 'dev.pfx']
+	] as const) {
+		it(`hands off discovered ${context}`, async () => {
+			const value = {
+				paths: [`C:\\out\\${pathName}`],
+				sourceTruncated: false,
+				displayTruncated: false
+			};
+			const result = await discoverSignFilesWithFallback(
+				context,
+				async () => ({ cancelled: false, value }),
+				async () => { throw new Error('warning should not be shown'); }
+			);
+			assert.deepEqual(result, { cancelled: false, result: value });
+		});
+	}
+
+	it('preserves truncation metadata from workspace discovery', async () => {
+		const value = {
+			paths: ['C:\\out\\app.msix'],
+			sourceTruncated: true,
+			displayTruncated: false
+		};
+
+		const result = await discoverSignFilesWithFallback(
+			'signable artifacts',
+			async () => ({ cancelled: false, value }),
+			async () => { throw new Error('warning should not be shown'); }
+		);
+
+		assert.deepEqual(result, { cancelled: false, result: value });
+	});
+
+	it('includes failure context and requests Browse when selected', async () => {
+		let warning = '';
+		const result = await discoverSignFilesWithFallback(
+			'signable artifacts',
+			async () => { throw new Error('search unavailable'); },
+			async message => {
+				warning = message;
+				return 'Browse…';
+			}
+		);
+
+		assert.match(warning, /signable artifacts: search unavailable/);
+		assert.deepEqual(result, { cancelled: false, browseRequested: true });
+	});
+
+	it('does not request Browse when the warning is dismissed', async () => {
+		const result = await discoverSignFilesWithFallback(
+			'signing certificates',
+			async () => { throw new Error('search unavailable'); },
+			async () => undefined
+		);
+		assert.deepEqual(result, { cancelled: false, browseRequested: false });
+	});
+
+	it('bypasses the warning when discovery is cancelled', async () => {
+		let warningShown = false;
+		const result = await discoverSignFilesWithFallback(
+			'signable artifacts',
+			async () => ({
+				cancelled: true,
+				value: { paths: [], sourceTruncated: false, displayTruncated: false }
+			}),
+			async () => {
+				warningShown = true;
+				return 'Browse…';
+			}
+		);
+		assert.deepEqual(result, {
+			cancelled: true,
+			result: { paths: [], sourceTruncated: false, displayTruncated: false }
+		});
+		assert.equal(warningShown, false);
+	});
+});
+
+describe('handoffSignFileDiscovery', () => {
+	it('invokes manual selection once for a direct empty discovery and returns its result', async () => {
+		let calls = 0;
+		const result = await handoffSignFileDiscovery(
+			{
+				cancelled: false,
+				result: { paths: [], sourceTruncated: false, displayTruncated: false }
+			},
+			async () => {
+				calls++;
+				return 'C:\\manual\\app.msix';
+			}
+		);
+
+		assert.equal(result, 'C:\\manual\\app.msix');
+		assert.equal(calls, 1);
+	});
+
+	it('does not invoke manual selection when a truncated empty discovery warning is dismissed', async () => {
+		let calls = 0;
+		let warning = '';
+		const result = await handoffSignFileDiscovery(
+			{
+				cancelled: false,
+				result: { paths: [], sourceTruncated: true, displayTruncated: false }
+			},
+			async () => {
+				calls++;
+				return 'unexpected';
+			},
+			{
+				searchContext: 'signing certificates',
+				showWarning: async message => {
+					warning = message;
+					return undefined;
+				}
+			}
+		);
+
+		assert.equal(result, undefined);
+		assert.equal(calls, 0);
+		assert.match(warning, /first 500 workspace matches/i);
+		assert.match(warning, /signing certificates/i);
+	});
+
+	for (const [kind, manualPath] of [
+		['artifact', 'C:\\manual\\app.msix'],
+		['certificate', 'C:\\manual\\cert.pfx']
+	] as const) {
+		it(`invokes the ${kind} manual selector once when Browse was requested`, async () => {
+			let calls = 0;
+			const result = await handoffSignFileDiscovery(
+				{ cancelled: false, browseRequested: true },
+				async () => {
+					calls++;
+					return manualPath;
+				}
+			);
+
+			assert.equal(result, manualPath);
+			assert.equal(calls, 1);
+		});
+	}
+
+	for (const discovery of [
+		{
+			cancelled: true,
+			result: { paths: [], sourceTruncated: false, displayTruncated: false }
+		},
+		{ cancelled: false, browseRequested: false }
+	]) {
+		it(`does not invoke manual selection for ${discovery.cancelled ? 'cancellation' : 'dismissal'}`, async () => {
+			let calls = 0;
+			const result = await handoffSignFileDiscovery(discovery, async () => {
+				calls++;
+				return 'unexpected';
+			});
+
+			assert.equal(result, undefined);
+			assert.equal(calls, 0);
+		});
+	}
+
+	it('continues with normal discovered paths without invoking manual selection', async () => {
+		const discovered = {
+			paths: ['C:\\out\\app.msix'],
+			sourceTruncated: true,
+			displayTruncated: false
+		};
+		let calls = 0;
+
+		const result = await handoffSignFileDiscovery(
+			{ cancelled: false, result: discovered },
+			async () => {
+				calls++;
+				return 'unexpected';
+			}
+		);
+
+		assert.equal(result, discovered);
+		assert.equal(calls, 0);
+	});
+});
+
+describe('coordinateWorkspaceSignFileSelection', () => {
+	it('shows discovered workspace items plus a partial-results Browse option', async () => {
+		const discovery = {
+			cancelled: false,
+			result: {
+				paths: ['C:\\workspace\\output\\app.msix'],
+				sourceTruncated: true,
+				displayTruncated: false
+			}
+		};
+		let warningShown = false;
+		let manualCalls = 0;
+		let quickPickItems: Array<{ label: string; description?: string; detail: string }> = [];
+
+		const result = await coordinateWorkspaceSignFileSelection('C:\\workspace', discovery, {
+			searchContext: 'signable artifacts',
+			placeHolder: 'Select a package to sign',
+			selectManualFile: async () => {
+				manualCalls++;
+				return 'C:\\manual\\fallback.msix';
+			},
+			showWarning: async () => {
+				warningShown = true;
+				return 'Browse…';
+			},
+			showQuickPick: async items => {
+				quickPickItems = [...items];
+				return items[1];
+			}
+		});
+
+		assert.equal(result, 'C:\\manual\\fallback.msix');
+		assert.equal(warningShown, false);
+		assert.equal(manualCalls, 1);
+		assert.deepEqual(quickPickItems[0], createWorkspaceSignFileQuickPickItem('C:\\workspace', 'C:\\workspace\\output\\app.msix'));
+		assert.match(quickPickItems[1].label, /browse/i);
+		assert.match(quickPickItems[1].detail, /first 500 workspace matches/i);
+		assert.match(quickPickItems[1].detail, /browse to choose a different file manually/i);
+	});
+
+	it('surfaces an explicit warning before manual Browse when bounded discovery yields no displayable paths', async () => {
+		let warning = '';
+		let quickPickCalls = 0;
+		let manualCalls = 0;
+
+		const result = await coordinateWorkspaceSignFileSelection('C:\\workspace', {
+			cancelled: false,
+			result: {
+				paths: [],
+				sourceTruncated: true,
+				displayTruncated: false
+			}
+		}, {
+			searchContext: 'signable artifacts',
+			placeHolder: 'Select a package to sign',
+			selectManualFile: async () => {
+				manualCalls++;
+				return 'C:\\manual\\bounded.msix';
+			},
+			showWarning: async message => {
+				warning = message;
+				return 'Browse…';
+			},
+			showQuickPick: async () => {
+				quickPickCalls++;
+				return undefined;
+			}
+		});
+
+		assert.equal(result, 'C:\\manual\\bounded.msix');
+		assert.equal(quickPickCalls, 0);
+		assert.equal(manualCalls, 1);
+		assert.match(warning, /first 500 workspace matches/i);
+		assert.match(warning, /signable artifacts/i);
+		assert.match(warning, /additional matching files may still exist/i);
+	});
+});
+
+describe('createSignBrowseItem', () => {
+	it('discloses when source discovery and the displayed list are truncated', () => {
+		const item = createSignBrowseItem({ sourceTruncated: true, displayTruncated: true });
+
+		assert.match(item.label, /more files available/i);
+		assert.match(item.detail, /newest 100 of the first 500/i);
+		assert.match(item.detail, /additional workspace matches may exist/i);
+		assert.match(item.detail, /browse to choose a different file manually/i);
+	});
+
+	it('discloses when only the displayed list is truncated', () => {
+		const item = createSignBrowseItem({ sourceTruncated: false, displayTruncated: true });
+
+		assert.match(item.label, /more files available/i);
+		assert.match(item.detail, /newest 100 matching files/i);
+		assert.match(item.detail, /browse to choose a different file manually/i);
+	});
+
+	it('discloses when only source discovery is truncated', () => {
+		const item = createSignBrowseItem({ sourceTruncated: true, displayTruncated: false });
+
+		assert.match(item.label, /additional files may exist/i);
+		assert.match(item.detail, /first 500 workspace matches/i);
+		assert.match(item.detail, /browse to choose a different file manually/i);
+	});
+
+	it('uses the normal Browse wording for complete discovery', () => {
+		assert.deepEqual(
+			createSignBrowseItem({ sourceTruncated: false, displayTruncated: false }),
+			{ label: '$(folder-opened) Browse…', detail: 'Open a file picker' }
+		);
 	});
 });
 
@@ -129,10 +1027,14 @@ describe('findWorkspaceArtifacts with CERTIFICATE_GLOBS', () => {
 		createFile(path.join(tempDir, 'devcert.pfx'));
 		createFile(path.join(tempDir, 'certs', 'prod.pfx'));
 
-		const results = await findWorkspaceArtifacts(tempDir, CERTIFICATE_GLOBS);
+		const results = await findWorkspaceArtifacts(
+			tempDir,
+			createFinder([path.join(tempDir, 'devcert.pfx'), path.join(tempDir, 'certs', 'prod.pfx')]),
+			CERTIFICATE_GLOBS
+		);
 
 		assert.deepEqual(
-			results.map(filePath => path.basename(filePath)).sort(),
+			results.paths.map(filePath => path.basename(filePath)).sort(),
 			['devcert.pfx', 'prod.pfx']
 		);
 	});
@@ -143,21 +1045,21 @@ describe('findWorkspaceArtifacts with CERTIFICATE_GLOBS', () => {
 		createFile(path.join(tempDir, 'app.msix'));
 		createFile(path.join(tempDir, 'cert.pem'));
 
-		const results = await findWorkspaceArtifacts(tempDir, CERTIFICATE_GLOBS);
+		const results = await findWorkspaceArtifacts(tempDir, createFinder([]), CERTIFICATE_GLOBS);
 
-		assert.deepEqual(results, []);
+		assert.deepEqual(results, { paths: [], sourceTruncated: false, displayTruncated: false });
 	});
 
-	it('excludes node_modules certificates', async () => {
-		const tempDir = createTempDir();
-		tempDirs.push(tempDir);
-		const included = path.join(tempDir, 'devcert.pfx');
-		createFile(included);
-		createFile(path.join(tempDir, 'node_modules', 'pkg', 'test.pfx'));
+	it('uses the certificate glob without a brace wrapper', async () => {
+		const finder: WorkspaceFileFinder = async (includePattern) => {
+			assert.equal(includePattern, '**/*.pfx');
+			return [];
+		};
 
-		const results = await findWorkspaceArtifacts(tempDir, CERTIFICATE_GLOBS);
-
-		assert.deepEqual(results, [included]);
+		assert.deepEqual(
+			await findWorkspaceArtifacts('C:\\workspace', finder, CERTIFICATE_GLOBS),
+			{ paths: [], sourceTruncated: false, displayTruncated: false }
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary
- replace the four per-pattern `glob` scans with one `vscode.workspace.findFiles` query
- pass the existing progress cancellation token to `findFiles` and stop remaining metadata work after cancellation
- preserve the existing signing flow, QuickPick items, sorting, Browse fallback, and certificate selection behavior
- keep artifacts hidden by `files.exclude` discoverable while continuing to omit `.git` and `node_modules`

## Deliberately out of scope
PR #161 owns executable/library discovery, command naming, result limits, package-first ordering, and the related QuickPick scenarios. This PR does not implement or duplicate those behaviors.

## Validation
- `npm run compile-tsc`
- targeted ESLint for the four changed TypeScript files
- `npx tsx --test src/test/sign-utils.test.ts` (18 passed)
- focused Playwright coverage for `files.exclude` and dependency filtering
- packaged-extension live test confirmed an AppPackages MSIX hidden by `files.exclude` remains visible while a `node_modules` MSIX does not

Closes #75
Closes #82