### PR TITLE
Add debug configuration action for inputFolder errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ For debugging, install the debugger extension that matches your app's language (
 
 | Problem | Cause | Solution |
 |---------|-------|----------|
+| **Invalid `inputFolder` notification when pressing F5** | The configured build output path is missing, is not a directory, or contains no `.exe`. | Select **Open debug configuration** in the notification to open the relevant debug or launch configuration, then correct `inputFolder`. |
 | **"No folders containing .exe files found in the workspace..."** or **"No build output folder selected..."** when pressing F5 | The project hasn't been built yet, or the build output is in an unexpected location. | Build your project first (e.g., `dotnet build`), or set `inputFolder` in `launch.json` to point to the folder containing your `.exe`. |
 | **Debugger doesn't attach** | The required debugger extension isn't installed. | Install the matching extension for your language — see [Supported debuggers](#integrated-debugging). |
 | **App launches but changes aren't visible** | The `winapp` debug type does not build the project automatically. | Rebuild your project before pressing F5, or add a `preLaunchTask` to automate it (see the tip in [Integrated Debugging](#integrated-debugging)). |

--- a/src/debugger-resolver.ts
+++ b/src/debugger-resolver.ts
@@ -31,7 +31,7 @@ export async function validateInputFolder(inputFolder: string, cwd: string): Pro
 			valid: false,
 			reason: 'not-found',
 			message: `The configured "inputFolder" path does not exist: ${inputFolder}. `
-				+ 'Build your project first, or update "inputFolder" in the debug configuration to point to your build output directory.'
+				+ 'Build your project first, or update "inputFolder" in launch.json to point to your build output directory.'
 		};
 	}
 
@@ -40,7 +40,7 @@ export async function validateInputFolder(inputFolder: string, cwd: string): Pro
 			valid: false,
 			reason: 'not-directory',
 			message: `The configured "inputFolder" is not a directory: ${inputFolder}. `
-				+ 'Update "inputFolder" in the debug configuration to point to the folder containing your built application.'
+				+ 'Update "inputFolder" in launch.json to point to the folder containing your built application.'
 		};
 	}
 
@@ -50,7 +50,7 @@ export async function validateInputFolder(inputFolder: string, cwd: string): Pro
 			valid: false,
 			reason: 'no-exe',
 			message: `The configured "inputFolder" does not contain any .exe files: ${inputFolder}. `
-				+ 'Build your project first, or update "inputFolder" in the debug configuration to point to the folder containing your built application.'
+				+ 'Build your project first, or update "inputFolder" in launch.json to point to the folder containing your built application.'
 		};
 	}
 

--- a/src/debugger-resolver.ts
+++ b/src/debugger-resolver.ts
@@ -31,7 +31,7 @@ export async function validateInputFolder(inputFolder: string, cwd: string): Pro
 			valid: false,
 			reason: 'not-found',
 			message: `The configured "inputFolder" path does not exist: ${inputFolder}. `
-				+ 'Build your project first, or update "inputFolder" in launch.json to point to your build output directory.'
+				+ 'Build your project first, or update "inputFolder" in the debug configuration to point to your build output directory.'
 		};
 	}
 
@@ -40,7 +40,7 @@ export async function validateInputFolder(inputFolder: string, cwd: string): Pro
 			valid: false,
 			reason: 'not-directory',
 			message: `The configured "inputFolder" is not a directory: ${inputFolder}. `
-				+ 'Update "inputFolder" in launch.json to point to the folder containing your built application.'
+				+ 'Update "inputFolder" in the debug configuration to point to the folder containing your built application.'
 		};
 	}
 
@@ -50,7 +50,7 @@ export async function validateInputFolder(inputFolder: string, cwd: string): Pro
 			valid: false,
 			reason: 'no-exe',
 			message: `The configured "inputFolder" does not contain any .exe files: ${inputFolder}. `
-				+ 'Build your project first, or update "inputFolder" in launch.json to point to the folder containing your built application.'
+				+ 'Build your project first, or update "inputFolder" in the debug configuration to point to the folder containing your built application.'
 		};
 	}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -834,7 +834,26 @@ class WinAppDebugConfigurationProvider implements vscode.DebugConfigurationProvi
 			}
 			const result = await validateInputFolder(inputFolder, cwd);
 			if (!result.valid) {
-				vscode.window.showErrorMessage(result.message);
+				const openDebugConfigurationAction = 'Open debug configuration';
+				void vscode.window.showErrorMessage(result.message, openDebugConfigurationAction).then(
+					action => {
+						if (action === openDebugConfigurationAction) {
+							void vscode.commands.executeCommand('workbench.action.debug.configure').then(
+								undefined,
+								error => {
+									void vscode.window.showErrorMessage(
+										`Failed to open debug configuration: ${error instanceof Error ? error.message : String(error)}`
+									).then(undefined, () => {});
+								}
+							);
+						}
+					},
+					error => {
+						void vscode.window.showErrorMessage(
+							`Failed to show inputFolder validation error: ${error instanceof Error ? error.message : String(error)}`
+						).then(undefined, () => {});
+					}
+				);
 				return undefined;
 			}
 		}

--- a/src/test/debugger-resolver.test.ts
+++ b/src/test/debugger-resolver.test.ts
@@ -105,7 +105,7 @@ describe('validateInputFolder', () => {
 			assert.equal(
 				result.message,
 				'The configured "inputFolder" path does not exist: C:\\does\\not\\exist. '
-					+ 'Build your project first, or update "inputFolder" in the debug configuration to point to your build output directory.'
+					+ 'Build your project first, or update "inputFolder" in launch.json to point to your build output directory.'
 			);
 		}
 	});
@@ -118,7 +118,7 @@ describe('validateInputFolder', () => {
 			assert.equal(
 				result.message,
 				`The configured "inputFolder" is not a directory: ${aFile}. `
-					+ 'Update "inputFolder" in the debug configuration to point to the folder containing your built application.'
+					+ 'Update "inputFolder" in launch.json to point to the folder containing your built application.'
 			);
 		}
 	});
@@ -131,7 +131,7 @@ describe('validateInputFolder', () => {
 			assert.equal(
 				result.message,
 				`The configured "inputFolder" does not contain any .exe files: ${emptyDir}. `
-					+ 'Build your project first, or update "inputFolder" in the debug configuration to point to the folder containing your built application.'
+					+ 'Build your project first, or update "inputFolder" in launch.json to point to the folder containing your built application.'
 			);
 		}
 	});

--- a/src/test/debugger-resolver.test.ts
+++ b/src/test/debugger-resolver.test.ts
@@ -102,7 +102,11 @@ describe('validateInputFolder', () => {
 		assert.equal(result.valid, false);
 		if (!result.valid) {
 			assert.equal(result.reason, 'not-found');
-			assert.match(result.message, /does not exist/);
+			assert.equal(
+				result.message,
+				'The configured "inputFolder" path does not exist: C:\\does\\not\\exist. '
+					+ 'Build your project first, or update "inputFolder" in the debug configuration to point to your build output directory.'
+			);
 		}
 	});
 
@@ -111,7 +115,11 @@ describe('validateInputFolder', () => {
 		assert.equal(result.valid, false);
 		if (!result.valid) {
 			assert.equal(result.reason, 'not-directory');
-			assert.match(result.message, /not a directory/);
+			assert.equal(
+				result.message,
+				`The configured "inputFolder" is not a directory: ${aFile}. `
+					+ 'Update "inputFolder" in the debug configuration to point to the folder containing your built application.'
+			);
 		}
 	});
 
@@ -120,7 +128,11 @@ describe('validateInputFolder', () => {
 		assert.equal(result.valid, false);
 		if (!result.valid) {
 			assert.equal(result.reason, 'no-exe');
-			assert.match(result.message, /does not contain any \.exe files/);
+			assert.equal(
+				result.message,
+				`The configured "inputFolder" does not contain any .exe files: ${emptyDir}. `
+					+ 'Build your project first, or update "inputFolder" in the debug configuration to point to the folder containing your built application.'
+			);
 		}
 	});
 

--- a/src/test/e2e/README.md
+++ b/src/test/e2e/README.md
@@ -44,7 +44,7 @@ Tests run against real AppxManifest files stored in `src/test/fixtures/`:
 
 ---
 
-## Test inventory (127 tests)
+## Test inventory (128 tests)
 
 ### `sign-quickpick.spec.ts` — 3 tests (2 active, 1 skipped)
 
@@ -55,6 +55,14 @@ Validates that `winapp.sign` discovers workspace MSIX artifacts and certificates
 | 1 | shows QuickPick with .msix file and Browse option when artifacts exist | QuickPick appears with artifact rows and Browse… fallback |
 | 2 | shows certificate QuickPick with .pfx file after selecting a package | Certificate QuickPick appears after package selection with .pfx rows and Browse… fallback |
 | 3 | *(skipped)* skips package QuickPick when invoked with prefilled path | Needs VS Code extension test host — see [#83](https://github.com/microsoft/WinAppVSCE/issues/83) |
+
+### `input-folder-validation.spec.ts` — 1 test
+
+Validates that an invalid configured `inputFolder` offers to open its owning debug configuration.
+
+| # | Test | Validates |
+|---|------|-----------|
+| 1 | invalid inputFolder offers to open its debug configuration | Validation cancels debugging, shows the resource-neutral action, and opens the correct folder `launch.json` with its unique configuration content |
 
 ### `editor-launch.spec.ts` — 11 tests
 

--- a/src/test/e2e/input-folder-validation.spec.ts
+++ b/src/test/e2e/input-folder-validation.spec.ts
@@ -1,0 +1,131 @@
+import {
+	test,
+	expect,
+	_electron as electron,
+	type ElectronApplication,
+	type Page
+} from '@playwright/test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const VSCODE_EXE =
+	process.env.VSCODE_PATH ??
+	path.join(os.homedir(), 'AppData', 'Local', 'Programs', 'Microsoft VS Code', 'Code.exe');
+const EXTENSION_ROOT = path.resolve(__dirname, '..', '..', '..');
+const pendingApps = new Set<ElectronApplication>();
+const pendingDirectories = new Set<string>();
+
+async function cleanupPendingResources(): Promise<void> {
+	const cleanupErrors: unknown[] = [];
+	for (const app of pendingApps) {
+		try {
+			await app.close();
+			pendingApps.delete(app);
+		} catch (error) {
+			cleanupErrors.push(new Error('Failed to close input-folder E2E application', { cause: error }));
+		}
+	}
+	for (const directory of pendingDirectories) {
+		try {
+			await fs.promises.rm(directory, {
+				recursive: true,
+				force: true,
+				maxRetries: 20,
+				retryDelay: 250
+			});
+			pendingDirectories.delete(directory);
+		} catch (error) {
+			cleanupErrors.push(new Error(`Failed to remove E2E directory ${directory}`, { cause: error }));
+		}
+	}
+	if (cleanupErrors.length > 0) {
+		throw new AggregateError(cleanupErrors, 'Input-folder E2E cleanup failed');
+	}
+}
+
+test.afterEach(cleanupPendingResources);
+test.afterAll(cleanupPendingResources);
+
+async function waitForReadyWorkbench(page: Page): Promise<void> {
+	await expect(page.locator('.monaco-workbench')).toBeVisible({ timeout: 20_000 });
+	await expect(page.locator('.tab.active')).toContainText('README.txt', { timeout: 20_000 });
+
+	const welcomeDialog = page.getByRole('dialog', { name: 'Welcome to Visual Studio Code' });
+	const welcomeAppeared = await welcomeDialog.waitFor({ state: 'visible', timeout: 5_000 })
+		.then(() => true, () => false);
+	if (welcomeAppeared) {
+		await welcomeDialog.getByRole('button', { name: 'Close' }).click();
+		await expect(welcomeDialog).toBeHidden({ timeout: 5_000 });
+	}
+	await expect(page.getByRole('dialog').filter({ visible: true })).toHaveCount(0, { timeout: 5_000 });
+
+	await page.keyboard.press('Control+Shift+D');
+	await expect(page.getByRole('button', { name: /Debug Launch Configurations: Invalid input folder/ }))
+		.toBeVisible({ timeout: 10_000 });
+	await expect(page.getByRole('button', { name: /Start Debugging \(F5\)/ })).toBeEnabled();
+}
+
+test('invalid inputFolder offers to open its debug configuration', async () => {
+	const workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'input-folder-e2e-'));
+	pendingDirectories.add(workspacePath);
+	const userDataPath = fs.mkdtempSync(path.join(os.tmpdir(), 'input-folder-e2e-user-'));
+	pendingDirectories.add(userDataPath);
+	const vscodePath = path.join(workspacePath, '.vscode');
+	const launchJsonPath = path.join(vscodePath, 'launch.json');
+	const readmePath = path.join(workspacePath, 'README.txt');
+	const sourceMarker = 'INPUT_FOLDER_E2E_WORKSPACE_LAUNCH';
+	fs.mkdirSync(vscodePath);
+	fs.writeFileSync(readmePath, 'Input folder validation test');
+	fs.writeFileSync(launchJsonPath, JSON.stringify({
+		version: '0.2.0',
+		configurations: [{
+			type: 'winapp',
+			request: 'launch',
+			name: 'Invalid input folder',
+			debuggerType: 'node',
+			inputFolder: path.join(workspacePath, 'missing-build-output'),
+			e2eSourceMarker: sourceMarker
+		}]
+	}, null, 2));
+
+	const app = await electron.launch({
+		executablePath: VSCODE_EXE,
+		args: [
+			workspacePath,
+			readmePath,
+			'--new-window',
+			`--user-data-dir=${userDataPath}`,
+			`--extensionDevelopmentPath=${EXTENSION_ROOT}`,
+			'--disable-telemetry',
+			'--skip-release-notes',
+			'--disable-workspace-trust'
+		],
+		timeout: 30_000
+	});
+	pendingApps.add(app);
+
+	const page = await app.firstWindow();
+	await page.waitForLoadState('domcontentloaded');
+	await waitForReadyWorkbench(page);
+
+	const notification = page.locator('.notification-toast')
+		.filter({ hasText: 'The configured "inputFolder" path does not exist' });
+	await page.keyboard.press('F5');
+	await expect(notification).toBeVisible({ timeout: 20_000 });
+
+	const debugToolbar = page.locator('.debug-toolbar');
+	await expect(debugToolbar).toBeHidden();
+	await expect(debugToolbar.getByRole('button').filter({ visible: true })).toHaveCount(0);
+	const startDebugging = page.getByRole('button', { name: /Start Debugging \(F5\)/ });
+	await expect(startDebugging).toBeVisible();
+	await expect(startDebugging).toBeEnabled();
+
+	const action = notification.getByText('Open debug configuration', { exact: true });
+	await expect(action).toBeVisible();
+	await action.click();
+
+	await expect(page.locator('.tab.active')).toContainText('launch.json', { timeout: 10_000 });
+	await expect(page.locator('.editor-group-container.active .view-lines'))
+		.toContainText(sourceMarker, { timeout: 10_000 });
+});


### PR DESCRIPTION
## Summary

Fixes #111.

When F5 is cancelled because a configured `inputFolder` is missing, is not a directory, or contains no executable, the error notification now offers **Open debug configuration**. The action delegates to VS Code's built-in debug configuration flow so users can immediately correct the owning configuration.

The validation guidance is now resource-neutral, and troubleshooting documentation describes the recovery path.

## Testing

- Full unit suite
- Targeted Playwright E2E covering invalid `inputFolder`, debug cancellation, notification action, and the opened configuration contents
- Production extension build and VSIX packaging
- Installed VSIX live-tested in an isolated VS Code instance through the WinApp UX driver
- Iterative PR review completed with no remaining high or medium findings