### PR TITLE
Improve VS Code driver command argument transport

### DIFF
--- a/.github/skills/vsce-testing/AGENTS.md
+++ b/.github/skills/vsce-testing/AGENTS.md
@@ -80,6 +80,7 @@ $onEditor = Confirm-VSCodeEditor -Ctx $ctx -OpenFileIfNeeded $file
 
 # 3. Push REAL extension commands to the LIVE instance and verify their effects.
 Invoke-VSCodeDriverCommand -Ctx $ctx -CommandId 'winapp.certGenerate' -Answers @(@{accept=$true})
+Invoke-VSCodeDriverCommand -Ctx $ctx -CommandId 'some.command' -Arguments @('value', 42)
 Invoke-VSCodeDriverDebug   -Ctx $ctx -InputFolder "$proj\bin\x64\Debug\net8.0-windows10.0.19041.0\win-x64"
 Invoke-VSCodeDriverOpenFile -Ctx $ctx -Path "$proj\Package.appxmanifest"
 
@@ -148,6 +149,10 @@ Answers (ordered, one per prompt the command raises):
   sign, certInstall). Targets the `File name:` edit field and clicks `Open`.
 - Free-text `showInputBox` prompts (e.g. cert password) **cannot** be auto-answered — avoid or accept
   defaults.
+
+Command arguments are passed with `-Arguments`; queue/script JSON uses `args`. Descriptors with
+`kind: activeDocumentUri`, `fileUri`, or `position` resolve to the corresponding VS Code API object.
+Legacy steps with `type: commandArgs` remain supported.
 
 `debug` steps use `launch.json`'s `inputFolder` (the app's built `win-x64` output). No dialogs.
 

--- a/.github/skills/vsce-testing/README.md
+++ b/.github/skills/vsce-testing/README.md
@@ -49,7 +49,8 @@ pwsh -NoProfile -File scripts\test-driver-queue.ps1 -Project <path-to-winui-proj
 # 3. Use the automation module interactively (see AGENTS.md for the full workflow)
 Import-Module .\scripts\vscode-drive.psm1 -Force
 $ctx = Start-VSCodeDrive -Folder <project> -OpenFile <file> -WithDriverExtension -SettleSec 24
-# ... drive commands, observe, screenshot ...
+Invoke-VSCodeDriverCommand -Ctx $ctx -CommandId 'some.command' -Arguments @('value', 42)
+# Add -Answers @(@{ accept = $true }) when the command raises prompts.
 Stop-VSCodeDrive -Ctx $ctx
 ```
 
@@ -83,6 +84,9 @@ The harness launches VS Code with a companion **driver-extension** that exposes 
 extension runs the command via `vscode.commands.executeCommand` /
 `vscode.debug.startDebugging` → writes `res-<id>.json` with the result. This
 exercises the **real extension command handlers** inside a live VS Code instance.
+Command steps accept an optional `args` array. Argument descriptors with
+`kind: activeDocumentUri`, `fileUri`, or `position` are resolved to VS Code API
+objects; legacy `commandArgs` steps remain supported.
 
 UIA (`winapp ui`) is used for clicking, reading UI state, and taking screenshots —
 but NOT for typing, since synthetic keyboard input is blocked in this environment.

--- a/.github/skills/vsce-testing/driver-extension/extension.js
+++ b/.github/skills/vsce-testing/driver-extension/extension.js
@@ -81,13 +81,28 @@ async function acceptQuickInput() {
   catch (e) { return 'accept-error:' + String(e); }
 }
 
-// Run a single command step. Invokes the command WITHOUT awaiting (it blocks on its own prompts),
-// then answers prompts in order: {accept:true} for QuickPick, {nativeDialogPath} for folder picker,
-// {nativeFileDialogPath} for file picker.
-async function runCommandStep(step, result) {
+// Run a command step. Ordinary command steps are not awaited because the command may block on
+// prompts; legacy commandArgs steps are awaited so existing scripted provider queries keep results.
+async function executeCommandStep(step, result) {
   const settle = step.settleMs || 1600;
+  const args = (step.args || []).map(resolveCommandArg);
+  const isLegacyCommandArgs = step.type === 'commandArgs';
   appendLog('driver-run.log', `command: ${step.command}`);
-  Promise.resolve(vscode.commands.executeCommand(step.command)).catch(e => appendLog('driver-run.log', `cmd ${step.command} threw: ${e}`));
+  if (isLegacyCommandArgs) {
+    let error = null;
+    let value = null;
+    try {
+      value = await vscode.commands.executeCommand(step.command, ...args);
+    } catch (e) {
+      error = String(e);
+    }
+    await delay(step.afterMs || 800);
+    result.steps.push({ type: 'commandArgs', command: step.command, result: value, error });
+    return;
+  }
+
+  Promise.resolve(vscode.commands.executeCommand(step.command, ...args))
+    .catch(e => appendLog('driver-run.log', `cmd ${step.command} threw: ${e}`));
   const answers = step.answers || [];
   const log = { type: 'command', command: step.command, answers: [] };
   for (const a of answers) {
@@ -345,18 +360,6 @@ async function saveDocumentStep(step, result) {
   result.steps.push({ type: 'saveDocument', saved });
 }
 
-async function commandArgsStep(step, result) {
-  let err = null;
-  let value = null;
-  try {
-    value = await vscode.commands.executeCommand(step.command, ...(step.args || []).map(resolveCommandArg));
-  } catch (e) {
-    err = String(e);
-  }
-  await delay(step.afterMs || 800);
-  result.steps.push({ type: 'commandArgs', command: step.command, result: value, error: err });
-}
-
 async function queryCompletionsStep(step, result) {
   const editor = requireActiveEditor();
   const position = toPosition(step.line, step.character);
@@ -445,7 +448,8 @@ async function revealDefinitionStep(step, result) {
 
 async function runStep(step, result) {
   switch (step.type) {
-    case 'command': await runCommandStep(step, result); break;
+    case 'command':
+    case 'commandArgs': await executeCommandStep(step, result); break;
     case 'debug': await runDebugStep(step, result); break;
     case 'stopDebug': await stopDebugStep(step, result); break;
     case 'openManifest': await openManifestStep(step, result); break;
@@ -454,7 +458,6 @@ async function runStep(step, result) {
     case 'setDocumentText': await setDocumentTextStep(step, result); break;
     case 'replaceText': await replaceTextStep(step, result); break;
     case 'saveDocument': await saveDocumentStep(step, result); break;
-    case 'commandArgs': await commandArgsStep(step, result); break;
     case 'queryCompletions': await queryCompletionsStep(step, result); break;
     case 'queryHover': await queryHoverStep(step, result); break;
     case 'queryDefinition': await queryDefinitionStep(step, result); break;
@@ -553,4 +556,8 @@ function activate(context) {
   }
 }
 function deactivate() {}
-module.exports = { activate, deactivate };
+module.exports = {
+  activate,
+  deactivate,
+  _test: { executeCommandStep, resolveCommandArg }
+};

--- a/.github/skills/vsce-testing/driver-extension/extension.test.js
+++ b/.github/skills/vsce-testing/driver-extension/extension.test.js
@@ -1,0 +1,94 @@
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+
+const calls = [];
+const activeUri = { scheme: 'file', fsPath: 'C:\\workspace\\active.xaml' };
+const vscode = {
+  Position: class Position {
+    constructor(line, character) {
+      this.line = line;
+      this.character = character;
+    }
+  },
+  Uri: {
+    file(path) {
+      return { scheme: 'file', fsPath: path };
+    }
+  },
+  commands: {
+    executeCommand(command, ...args) {
+      calls.push({ command, args });
+      if (command === 'test.prompted') return new Promise(() => {});
+      return command === 'test.awaited' ? Promise.resolve('result') : Promise.resolve();
+    }
+  },
+  window: {
+    activeTextEditor: { document: { uri: activeUri } }
+  }
+};
+
+const originalLoad = Module._load;
+Module._load = function(request, parent, isMain) {
+  return request === 'vscode' ? vscode : originalLoad(request, parent, isMain);
+};
+const { _test } = require('./extension');
+Module._load = originalLoad;
+
+test.beforeEach(() => {
+  calls.length = 0;
+});
+
+test('keeps legacy commandArgs argument resolution and result behavior', async () => {
+  const result = { steps: [] };
+  await _test.executeCommandStep({
+    type: 'commandArgs',
+    command: 'test.awaited',
+    args: [
+      { kind: 'activeDocumentUri' },
+      { kind: 'fileUri', path: 'C:\\workspace\\other.xaml' },
+      { kind: 'position', line: 4, character: 2 },
+      { unchanged: true }
+    ],
+    afterMs: 1
+  }, result);
+
+  assert.deepEqual(calls, [{
+    command: 'test.awaited',
+    args: [
+      activeUri,
+      { scheme: 'file', fsPath: 'C:\\workspace\\other.xaml' },
+      new vscode.Position(4, 2),
+      { unchanged: true }
+    ]
+  }]);
+  assert.deepEqual(result.steps, [{
+    type: 'commandArgs',
+    command: 'test.awaited',
+    result: 'result',
+    error: null
+  }]);
+});
+
+test('starts an ordinary command with arguments before answering prompts in order', async () => {
+  const result = { steps: [] };
+  await _test.executeCommandStep({
+    type: 'command',
+    command: 'test.prompted',
+    args: [
+      { kind: 'activeDocumentUri' },
+      { kind: 'position', line: 4, character: 2 }
+    ],
+    answers: [{ accept: true }, { accept: true }],
+    settleMs: 1,
+    afterMs: 1
+  }, result);
+
+  assert.deepEqual(calls.map(call => call.command), [
+    'test.prompted',
+    'workbench.action.acceptSelectedQuickOpenItem',
+    'workbench.action.acceptSelectedQuickOpenItem'
+  ]);
+  assert.deepEqual(calls[0].args, [activeUri, new vscode.Position(4, 2)]);
+  assert.deepEqual(result.steps[0].answers.map(answer => answer.kind), ['accept', 'accept']);
+});

--- a/.github/skills/vsce-testing/driver-extension/package.json
+++ b/.github/skills/vsce-testing/driver-extension/package.json
@@ -8,6 +8,9 @@
   "categories": ["Other"],
   "activationEvents": ["onStartupFinished"],
   "main": "./extension.js",
+  "scripts": {
+    "test": "node --test extension.test.js"
+  },
   "contributes": {
     "commands": [
       { "command": "winappUxDriver.runScript", "title": "Run Script", "category": "WinApp UX Driver" },

--- a/.github/skills/vsce-testing/scripts/vscode-drive.psm1
+++ b/.github/skills/vsce-testing/scripts/vscode-drive.psm1
@@ -477,17 +477,18 @@ function Invoke-VSCodeDriverStep {
     return [pscustomobject]@{ id = $id; done = $false; error = 'timeout' }
 }
 
-# Fire a winapp.* (or any) command by ID; answers is an ordered list of @{accept=$true} /
-# @{nativeDialogPath='...'} to satisfy the command's prompts.
+# Fire a winapp.* (or any) command by ID. Arguments are passed to
+# vscode.commands.executeCommand; answers satisfy prompts in order.
 function Invoke-VSCodeDriverCommand {
     param(
         [Parameter(Mandatory)]$Ctx,
         [Parameter(Mandatory)][string]$CommandId,
         [object[]]$Answers = @(),
         [int]$SettleMs = 1600,
-        [int]$TimeoutSec = 120
+        [int]$TimeoutSec = 120,
+        [object[]]$Arguments = @()
     )
-    return Invoke-VSCodeDriverStep -Ctx $Ctx -Step @{ type = 'command'; command = $CommandId; answers = $Answers; settleMs = $SettleMs } -TimeoutSec $TimeoutSec
+    return Invoke-VSCodeDriverStep -Ctx $Ctx -Step @{ type = 'command'; command = $CommandId; args = $Arguments; answers = $Answers; settleMs = $SettleMs } -TimeoutSec $TimeoutSec
 }
 
 # Launch the app via the WinApp DEBUGGER (vscode.debug.startDebugging).


### PR DESCRIPTION
## Summary
- pass generic command arguments from Invoke-VSCodeDriverCommand through the queue to vscode.commands.executeCommand
- consolidate command and legacy commandArgs execution while preserving commandArgs result behavior
- add focused Node tests for argument resolution/transport and prompt-answer ordering
- document the PowerShell and JSON argument forms

## Validation
- npm test --prefix .github/skills/vsce-testing/driver-extension
- node --check .github/skills/vsce-testing/driver-extension/extension.js
- PowerShell parser check for scripts/vscode-drive.psm1
- queue payload transport check
- git diff --check origin/main...HEAD