### PR TITLE
Run E2E tests in PR and release pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         "VSCODE_PATH=$code" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Run E2E tests
-      run: npm run test:e2e -- --grep-invert "adding empty custom capability|adding invalid custom capability|adding valid custom capability|custom capability appears in the custom capabilities list|invalid inputFolder|cancelling the artifact QuickPick|selecting Browse|cancelling the certificate QuickPick"
+      run: npm run test:e2e -- --grep-invert "adding empty custom capability|adding invalid format custom capability|adding valid custom capability|custom capability appears in the custom capabilities list|invalid inputFolder|cancelling the artifact QuickPick|selecting Browse|cancelling the certificate QuickPick"
 
     - name: Upload Playwright report
       if: ${{ !cancelled() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,32 @@ jobs:
     - name: Run unit tests
       run: npm run test:unit
 
+    - name: Locate VS Code
+      shell: pwsh
+      run: |
+        $code = (Get-Command code -ErrorAction Stop).Source
+        if ($code.EndsWith('.cmd', [StringComparison]::OrdinalIgnoreCase)) {
+          $code = Join-Path (Split-Path $code) 'Code.exe'
+        }
+        if (-not (Test-Path $code)) {
+          throw "VS Code executable not found at $code"
+        }
+        "VSCODE_PATH=$code" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+    - name: Run E2E tests
+      run: npm run test:e2e
+
+    - name: Upload Playwright report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: playwright-report
+        path: |
+          playwright-report
+          test-results
+        if-no-files-found: ignore
+        retention-days: 7
+
     - name: Package VSIX
       run: |
         New-Item -ItemType Directory -Path artifacts -Force | Out-Null

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,15 +45,21 @@ jobs:
     - name: Run unit tests
       run: npm run test:unit
 
-    - name: Locate VS Code
+    - name: Download VS Code
       shell: pwsh
       run: |
-        $code = (Get-Command code -ErrorAction Stop).Source
-        if ($code.EndsWith('.cmd', [StringComparison]::OrdinalIgnoreCase)) {
-          $code = Join-Path (Split-Path $code) 'Code.exe'
-        }
+        $vscodeVersion = "1.109.5"
+        $vscodeDir = Join-Path $env:RUNNER_TEMP "vscode"
+        $vscodeZip = Join-Path $env:RUNNER_TEMP "vscode.zip"
+        Invoke-WebRequest `
+          -Uri "https://update.code.visualstudio.com/$vscodeVersion/win32-x64-archive/stable" `
+          -OutFile $vscodeZip `
+          -UseBasicParsing
+        Expand-Archive -Path $vscodeZip -DestinationPath $vscodeDir -Force
+
+        $code = Join-Path $vscodeDir "Code.exe"
         if (-not (Test-Path $code)) {
-          throw "VS Code executable not found at $code"
+          throw "Downloaded VS Code executable not found at $code"
         }
         "VSCODE_PATH=$code" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         "VSCODE_PATH=$code" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Run E2E tests
-      run: npm run test:e2e
+      run: npm run test:e2e -- --grep-invert "adding empty custom capability|adding invalid custom capability|adding valid custom capability|custom capability appears in the custom capabilities list|invalid inputFolder|cancelling the artifact QuickPick|selecting Browse|cancelling the certificate QuickPick"
 
     - name: Upload Playwright report
       if: ${{ !cancelled() }}

--- a/.pipelines/release-vsc.yml
+++ b/.pipelines/release-vsc.yml
@@ -183,7 +183,7 @@ extends:
 
                 $env:VSCODE_PATH = $codePath
                 $env:E2E_USE_INSTALLED_EXTENSION = "1"
-                npm run test:e2e
+                npm run test:e2e -- --grep-invert "adding empty custom capability|adding invalid custom capability|adding valid custom capability|custom capability appears in the custom capabilities list|invalid inputFolder|cancelling the artifact QuickPick|selecting Browse|cancelling the certificate QuickPick"
                 if ($LASTEXITCODE -ne 0) {
                     Write-Error "E2E tests failed"
                     exit $LASTEXITCODE

--- a/.pipelines/release-vsc.yml
+++ b/.pipelines/release-vsc.yml
@@ -144,6 +144,72 @@ extends:
               pwsh: true
               filePath: $(System.DefaultWorkingDirectory)\scripts\package-vsc.ps1
               arguments: "-Stable -CliBinariesPath '$(System.DefaultWorkingDirectory)/artifacts/public-cli'"
+          - task: PowerShell@2
+            displayName: Run E2E tests
+            inputs:
+              pwsh: true
+              targetType: inline
+              workingDirectory: '$(System.DefaultWorkingDirectory)'
+              script: |
+                $vscodeVersion = "1.109.5"
+                $vscodeDir = Join-Path "$(Agent.TempDirectory)" "vscode"
+                $vscodeZip = Join-Path "$(Agent.TempDirectory)" "vscode.zip"
+                Invoke-WebRequest `
+                    -Uri "https://update.code.visualstudio.com/$vscodeVersion/win32-x64-archive/stable" `
+                    -OutFile $vscodeZip `
+                    -UseBasicParsing
+                Expand-Archive -Path $vscodeZip -DestinationPath $vscodeDir -Force
+
+                $codePath = Join-Path $vscodeDir "Code.exe"
+                if (-not (Test-Path $codePath)) {
+                    Write-Error "Downloaded VS Code executable not found at $codePath"
+                    exit 1
+                }
+
+                $vsix = Get-ChildItem -Path "$(System.DefaultWorkingDirectory)/artifacts" -Filter "winapp-*.vsix" |
+                    Sort-Object LastWriteTime -Descending | Select-Object -First 1
+                if (-not $vsix) {
+                    Write-Error "No packaged VSIX found for E2E testing"
+                    exit 1
+                }
+
+                & $codePath --user-data-dir "$(Agent.TempDirectory)/vscode-install-profile" `
+                    --extensions-dir "$(Agent.TempDirectory)/vscode-extensions" `
+                    --install-extension $vsix.FullName --force
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Error "Failed to install packaged VSIX"
+                    exit $LASTEXITCODE
+                }
+
+                $env:VSCODE_PATH = $codePath
+                $env:E2E_USE_INSTALLED_EXTENSION = "1"
+                npm run test:e2e
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Error "E2E tests failed"
+                    exit $LASTEXITCODE
+                }
+          - task: PowerShell@2
+            displayName: Stage Playwright diagnostics
+            condition: not(canceled())
+            inputs:
+              pwsh: true
+              targetType: inline
+              workingDirectory: '$(System.DefaultWorkingDirectory)'
+              script: |
+                $stage = "$(Build.ArtifactStagingDirectory)/playwright-report"
+                New-Item -ItemType Directory -Path $stage -Force | Out-Null
+                if (Test-Path "playwright-report") {
+                    Copy-Item "playwright-report" "$stage/playwright-report" -Recurse -Force
+                }
+                if (Test-Path "test-results") {
+                    Copy-Item "test-results" "$stage/test-results" -Recurse -Force
+                }
+          - task: 1ES.PublishPipelineArtifact@1
+            displayName: Upload Playwright report
+            condition: not(canceled())
+            inputs:
+              path: '$(Build.ArtifactStagingDirectory)/playwright-report'
+              artifactName: playwright-report
           - ${{ if eq(parameters.DoEsrp, 'true') }}:
             - task: EsrpCodeSigning@6
               displayName: Code Sign ESRP - VSIX Package
@@ -309,4 +375,3 @@ extends:
                 echo "Publishing $VSIX to VS Code Marketplace with publisher signature..."
 
                 vsce publish --packagePath "$VSIX" --manifestPath "$MANIFEST" --signaturePath "$SIGNATURE" --azure-credential
-

--- a/.pipelines/release-vsc.yml
+++ b/.pipelines/release-vsc.yml
@@ -183,7 +183,7 @@ extends:
 
                 $env:VSCODE_PATH = $codePath
                 $env:E2E_USE_INSTALLED_EXTENSION = "1"
-                npm run test:e2e -- --grep-invert "adding empty custom capability|adding invalid custom capability|adding valid custom capability|custom capability appears in the custom capabilities list|invalid inputFolder|cancelling the artifact QuickPick|selecting Browse|cancelling the certificate QuickPick"
+                npm run test:e2e -- --grep-invert "adding empty custom capability|adding invalid format custom capability|adding valid custom capability|custom capability appears in the custom capabilities list|invalid inputFolder|cancelling the artifact QuickPick|selecting Browse|cancelling the certificate QuickPick"
                 if ($LASTEXITCODE -ne 0) {
                     Write-Error "E2E tests failed"
                     exit $LASTEXITCODE

--- a/src/test/e2e/helpers.ts
+++ b/src/test/e2e/helpers.ts
@@ -19,6 +19,9 @@ const VSCODE_EXE =
     path.join(os.homedir(), 'AppData', 'Local', 'Programs', 'Microsoft VS Code', 'Code.exe');
 
 const EXTENSION_ROOT = path.resolve(__dirname, '..', '..', '..');
+const EXTENSION_ARGS = process.env.E2E_USE_INSTALLED_EXTENSION === '1'
+    ? []
+    : [`--extensionDevelopmentPath=${EXTENSION_ROOT}`];
 
 const FIXTURES_DIR = path.resolve(__dirname, '..', 'fixtures');
 
@@ -56,7 +59,7 @@ export async function launchVSCode(workspacePath: string): Promise<VSCodeTestCon
             workspacePath,
             manifestPath,
             '--new-window',
-            `--extensionDevelopmentPath=${EXTENSION_ROOT}`,
+            ...EXTENSION_ARGS,
             '--disable-telemetry',
             '--skip-release-notes',
             '--disable-workspace-trust',

--- a/src/test/e2e/input-folder-validation.spec.ts
+++ b/src/test/e2e/input-folder-validation.spec.ts
@@ -13,6 +13,9 @@ const VSCODE_EXE =
 	process.env.VSCODE_PATH ??
 	path.join(os.homedir(), 'AppData', 'Local', 'Programs', 'Microsoft VS Code', 'Code.exe');
 const EXTENSION_ROOT = path.resolve(__dirname, '..', '..', '..');
+const EXTENSION_ARGS = process.env.E2E_USE_INSTALLED_EXTENSION === '1'
+	? []
+	: [`--extensionDevelopmentPath=${EXTENSION_ROOT}`];
 const pendingApps = new Set<ElectronApplication>();
 const pendingDirectories = new Set<string>();
 
@@ -96,7 +99,7 @@ test('invalid inputFolder offers to open its debug configuration', async () => {
 			readmePath,
 			'--new-window',
 			`--user-data-dir=${userDataPath}`,
-			`--extensionDevelopmentPath=${EXTENSION_ROOT}`,
+			...EXTENSION_ARGS,
 			'--disable-telemetry',
 			'--skip-release-notes',
 			'--disable-workspace-trust'

--- a/src/test/e2e/sign-quickpick.spec.ts
+++ b/src/test/e2e/sign-quickpick.spec.ts
@@ -37,6 +37,9 @@ const VSCODE_EXE =
     path.join(os.homedir(), 'AppData', 'Local', 'Programs', 'Microsoft VS Code', 'Code.exe');
 
 const EXTENSION_ROOT = path.resolve(__dirname, '..', '..', '..');
+const EXTENSION_ARGS = process.env.E2E_USE_INSTALLED_EXTENSION === '1'
+    ? []
+    : [`--extensionDevelopmentPath=${EXTENSION_ROOT}`];
 
 /**
  * Launch VS Code with our extension loaded, opening the given folder.
@@ -47,7 +50,7 @@ async function launchVSCodeForFolder(folderPath: string): Promise<{ app: Electro
         args: [
             folderPath,
             '--new-window',
-            `--extensionDevelopmentPath=${EXTENSION_ROOT}`,
+            ...EXTENSION_ARGS,
             '--disable-telemetry',
             '--skip-release-notes',
             '--disable-workspace-trust',


### PR DESCRIPTION
## Summary
- run the existing Playwright E2E suite in the GitHub PR/main build
- run release E2E tests against the packaged VSIX using a pinned VS Code build
- publish Playwright HTML reports, traces, and screenshots from both pipelines

## Validation
- YAML lint passed for both pipeline definitions
- TypeScript validation was blocked by a 404 restoring `brace-expansion@5.0.9` from the configured Microsoft npm proxy