### PR TITLE
Bump VS Code extension version to 0.3.1 for development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "winapp",
-  "version": "0.2.2",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "winapp",
-      "version": "0.2.2",
+      "version": "0.3.1",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.9",
         "glob": "^13.0.6"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "WinApp extension for Visual Studio Code to assist in building, debugging, and packaging Windows applications. Includes schema-aware IntelliSense for AppxManifest.xml files.",
   "publisher": "Microsoft-WinAppCLI",
   "icon": "images/icon.png",
-  "version": "0.2.2",
+  "version": "0.3.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/WinAppVSCE.git"
@@ -161,7 +161,11 @@
         },
         "winapp.manifest.diagnostics.level": {
           "type": "string",
-          "enum": ["off", "warning", "error"],
+          "enum": [
+            "off",
+            "warning",
+            "error"
+          ],
           "default": "warning",
           "description": "Diagnostic filter for manifest schema validation. Set to 'off' to disable validation, 'warning' to show all diagnostics, or 'error' to show only errors."
         },


### PR DESCRIPTION
Auto-generated version bump after releasing VS Code extension v0.3.0.

This PR bumps the patch version in `package.json` from `0.3.0` to `0.3.1` so that prerelease builds pick up the new version number.