### PR TITLE
Improve WinApp CLI release downloads

### DIFF
--- a/.pipelines/release-vsc.yml
+++ b/.pipelines/release-vsc.yml
@@ -67,64 +67,12 @@ extends:
             displayName: Download public CLI release for VS Code extension
             env:
               GH_TOKEN: $(GITHUB_TOKEN)
+              WINAPP_CLI_RELEASE_TAG: ${{ parameters.CliReleaseTag }}
             inputs:
               pwsh: true
               errorActionPreference: 'stop'
-              targetType: 'inline'
-              script: |
-                $cliReleaseTag = "${{ parameters.CliReleaseTag }}"
-                $repo = "microsoft/winappcli"
-
-                if ([string]::IsNullOrWhiteSpace($cliReleaseTag)) {
-                    Write-Host "No CLI release tag specified, finding latest stable release..."
-                    $releases = gh release list --repo $repo --limit 10 --json tagName,isPrerelease,isDraft | ConvertFrom-Json
-                    $stableRelease = $releases | Where-Object { -not $_.isPrerelease -and -not $_.isDraft } | Select-Object -First 1
-                    if (-not $stableRelease) {
-                        Write-Error "No stable release found for $repo"
-                        exit 1
-                    }
-                    $cliReleaseTag = $stableRelease.tagName
-                    Write-Host "Found latest stable release: $cliReleaseTag"
-                } else {
-                    Write-Host "Using specified CLI release tag: $cliReleaseTag"
-                }
-
-                Write-Host "##vso[task.setvariable variable=CliReleaseTag]$cliReleaseTag"
-
-                # Download x64 and arm64 CLI zips using gh CLI
-                $cliDir = "$(System.DefaultWorkingDirectory)/artifacts/public-cli"
-
-                New-Item -ItemType Directory -Path "$cliDir/win-x64" -Force | Out-Null
-                New-Item -ItemType Directory -Path "$cliDir/win-arm64" -Force | Out-Null
-
-                Write-Host "Downloading CLI binaries from release $cliReleaseTag..."
-                gh release download $cliReleaseTag --repo $repo --pattern "winappcli-x64.zip" --dir $cliDir
-                if ($LASTEXITCODE -ne 0) {
-                    Write-Error "Failed to download winappcli-x64.zip from release $cliReleaseTag"
-                    exit 1
-                }
-
-                gh release download $cliReleaseTag --repo $repo --pattern "winappcli-arm64.zip" --dir $cliDir
-                if ($LASTEXITCODE -ne 0) {
-                    Write-Error "Failed to download winappcli-arm64.zip from release $cliReleaseTag"
-                    exit 1
-                }
-
-                # Extract
-                Expand-Archive -Path "$cliDir/winappcli-x64.zip" -DestinationPath "$cliDir/win-x64" -Force
-                Expand-Archive -Path "$cliDir/winappcli-arm64.zip" -DestinationPath "$cliDir/win-arm64" -Force
-
-                # Validate
-                if (-not (Test-Path "$cliDir/win-x64/winapp.exe")) {
-                    Write-Error "winapp.exe not found in extracted x64 archive"
-                    exit 1
-                }
-                if (-not (Test-Path "$cliDir/win-arm64/winapp.exe")) {
-                    Write-Error "winapp.exe not found in extracted arm64 archive"
-                    exit 1
-                }
-
-                Write-Host "CLI binaries ($cliReleaseTag) downloaded and validated successfully"
+              filePath: $(System.DefaultWorkingDirectory)\scripts\download-cli.ps1
+              arguments: "-DestinationPath '$(System.DefaultWorkingDirectory)/artifacts/public-cli'"
           - task: PowerShell@2
             displayName: Create temporary .npmrc for Build
             inputs:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,40 @@
+# Release checklist — WinApp VS Code extension
+
+This checklist tracks decisions and prerequisites for cutting a release, so recurring release-time
+concerns are documented and accepted rather than left as inline TODOs in the pipeline.
+
+## Starting a release
+
+From an authenticated, clean `main` checkout, preview the release automation first:
+
+```powershell
+.\scripts\start-vsc-release.ps1 -DryRun
+```
+
+Then run `.\scripts\start-vsc-release.ps1` (optionally with `-Version Major.Minor.Patch`).
+The script creates and pushes `vsc-rel/v<version>`, which triggers the release pipeline, then
+opens the follow-up patch-version PR. Git push access is required; an authenticated GitHub CLI
+creates the follow-up PR automatically; when `gh` is not installed, the script prints a browser URL
+for creating it manually.
+
+Pipeline runs may select a specific `CliReleaseTag`; leaving it empty downloads the latest stable
+WinApp CLI release. Production publishing requires `DoEsrp=true`, while `SkipPublish=true`
+produces artifacts without publishing.
+
+## WinApp CLI bundle
+
+The release pipeline calls `scripts/download-cli.ps1` with its artifact staging directory as
+`-DestinationPath`. For local development, omitting `-DestinationPath` keeps the existing behavior
+of installing the x64 and arm64 binaries under `bin`.
+
+An explicit `-Tag` takes precedence over `WINAPP_CLI_RELEASE_TAG`; when neither is set, the script
+downloads the latest stable WinApp CLI release.
+
+## Release checks
+
+- [ ] Run `npm run test:unit` and `npm test`.
+- [ ] Run `.\scripts\download-cli.ps1` and confirm both `bin/win-x64/winapp.exe` and
+      `bin/win-arm64/winapp.exe` are present.
+- [ ] Run `.\scripts\package-vsc.ps1 -Stable` and confirm the VSIX is created in `artifacts`.
+- [ ] Confirm the release pipeline's `CliReleaseTag` selects the intended WinApp CLI release.
+- [ ] Use `SkipPublish=true` when validating release artifacts without publishing them.

--- a/scripts/download-cli.ps1
+++ b/scripts/download-cli.ps1
@@ -10,6 +10,8 @@
     The release tag to download (e.g., "v0.3.2").
     Use "latest" to download the latest stable release.
     Defaults to "latest".
+.PARAMETER DestinationPath
+    Directory that receives win-x64 and win-arm64. Defaults to the repository bin directory.
 .EXAMPLE
     .\scripts\download-cli.ps1
     .\scripts\download-cli.ps1 -Tag v0.3.2
@@ -18,13 +20,29 @@
 
 param(
     [Parameter(Mandatory=$false)]
-    [string]$Tag = "latest"
+    [string]$Tag,
+
+    [Parameter(Mandatory=$false)]
+    [string]$DestinationPath
 )
 
 $ErrorActionPreference = "Stop"
 $repo = "microsoft/winappcli"
 $projectRoot = Split-Path $PSScriptRoot -Parent
-$binDir = Join-Path $projectRoot "bin"
+$Tag = if ([string]::IsNullOrWhiteSpace($Tag)) {
+    if ([string]::IsNullOrWhiteSpace($env:WINAPP_CLI_RELEASE_TAG)) { "latest" }
+    else { $env:WINAPP_CLI_RELEASE_TAG }
+} else {
+    $Tag
+}
+if ($Tag -notmatch '^(latest|v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$') {
+    throw "Invalid WinApp CLI release tag: '$Tag'"
+}
+$binDir = if ([string]::IsNullOrWhiteSpace($DestinationPath)) {
+    Join-Path $projectRoot "bin"
+} else {
+    [System.IO.Path]::GetFullPath($DestinationPath)
+}
 
 # Resolve "latest" to actual tag
 if ($Tag -eq "latest") {


### PR DESCRIPTION
## Summary
- restore focused release documentation from the earlier PR #50 work
- generalize `download-cli.ps1` with destination-path and release-tag overrides while preserving existing defaults
- reuse the downloader in the release pipeline instead of duplicating its logic

This work was separated from PR #50 so the release documentation and CLI download improvements can be reviewed independently from the XAML language service.

## Validation
- PowerShell syntax parsing
- mocked end-to-end downloader extraction for x64 and arm64 assets
- invalid release-tag rejection
- historical downloader parity with commit `182aba2` and focused pipeline-wiring checks