### PR TITLE
Open the active manifest directly from the editor title bar button

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1208,7 +1208,13 @@ export function activate(context: vscode.ExtensionContext) {
 	);
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand('winapp.openManifestEditor', async () => {
+		vscode.commands.registerCommand('winapp.openManifestEditor', async (resource?: vscode.Uri) => {
+			// Invoked from the editor title bar: open that manifest directly, no quick pick.
+			if (resource instanceof vscode.Uri && isManifestPath(resource.fsPath)) {
+				await vscode.commands.executeCommand('vscode.openWith', resource, ManifestEditorProvider.viewType);
+				return;
+			}
+
 			const manifests = (await Promise.all(
 				MANIFEST_SELECTOR.map(selector =>
 					vscode.workspace.findFiles(selector.pattern as string, BUILD_OUTPUT_EXCLUDE_GLOB)

--- a/src/test/e2e/README.md
+++ b/src/test/e2e/README.md
@@ -46,7 +46,7 @@ Tests run against real AppxManifest files stored in `src/test/fixtures/`:
 
 ---
 
-## Test inventory (128 tests)
+## Test inventory (130 tests)
 
 ### `sign-quickpick.spec.ts` — 6 tests
 
@@ -220,6 +220,15 @@ Validates error handling for malformed manifests. This spec launches its own VS 
 | # | Test | Validates |
 |---|------|-----------|
 | 1 | shows error view for malformed XML | Malformed manifest XML opens the error view with expected message and "Open in Text Editor" action |
+
+### `open-manifest-editor-command.spec.ts` — 2 tests
+
+Validates the two invocation paths of `winapp.openManifestEditor`. This spec launches its own VS Code instance with two manifests in the workspace.
+
+| # | Test | Validates |
+|---|------|-----------|
+| 1 | title bar button opens the active manifest without a quick pick | Editor title bar button passes the active resource through and opens it directly in the custom editor — no manifest picker |
+| 2 | Command Palette invocation shows the manifest quick pick | Palette invocation (no resource argument) lists workspace manifests plus the Browse… entry |
 
 ### `push-notifications-fixture.spec.ts` — 8 tests
 

--- a/src/test/e2e/open-manifest-editor-command.spec.ts
+++ b/src/test/e2e/open-manifest-editor-command.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * E2E tests: `winapp.openManifestEditor` invocation paths.
+ *
+ * - Editor title bar button → opens the active manifest directly (no quick pick).
+ * - Command Palette → shows the quick pick of manifests in the workspace.
+ */
+
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+    createTempWorkspace,
+    launchVSCode,
+    getWebviewFrame,
+    teardown,
+    type VSCodeTestContext,
+} from './helpers';
+
+let ctx: VSCodeTestContext;
+
+const QUICK_INPUT = '.quick-input-widget';
+const TITLE_BAR_BUTTON = '.editor-actions a.action-label[aria-label*="Open Manifest Editor"]';
+
+test.beforeAll(async () => {
+    const tmpDir = createTempWorkspace('winui-gallery.appxmanifest');
+    // A second manifest so the Command Palette quick pick has multiple entries.
+    const secondDir = path.join(tmpDir, 'Second');
+    fs.mkdirSync(secondDir, { recursive: true });
+    fs.copyFileSync(path.join(tmpDir, 'AppxManifest.xml'), path.join(secondDir, 'AppxManifest.xml'));
+
+    ctx = await launchVSCode(tmpDir);
+});
+
+test.afterAll(async () => {
+    if (ctx) { await teardown(ctx); }
+});
+
+test('title bar button opens the active manifest without a quick pick', async () => {
+    // The manifest was opened in the default text editor by the launch args.
+    const button = ctx.page.locator(TITLE_BAR_BUTTON).first();
+    await expect(button).toBeVisible({ timeout: 15_000 });
+
+    await button.click();
+    // No manifest picker should appear — the active file is used directly.
+    await ctx.page.waitForTimeout(2_000);
+    await expect(ctx.page.locator(QUICK_INPUT)).toBeHidden();
+
+    // The custom editor should have taken over for the active manifest.
+    const frame = await getWebviewFrame(ctx.page);
+    await expect(frame.locator('.tab-bar')).toBeVisible();
+
+    // Button is hidden once the custom editor is active.
+    await expect(ctx.page.locator(TITLE_BAR_BUTTON)).toHaveCount(0);
+});
+
+test('Command Palette invocation shows the manifest quick pick', async () => {
+    await ctx.page.keyboard.press('Control+Shift+P');
+    await ctx.page.waitForTimeout(1_000);
+    await ctx.page.keyboard.type('WinApp: Open Manifest Editor', { delay: 30 });
+    await ctx.page.waitForTimeout(1_500);
+    await ctx.page.keyboard.press('Enter');
+    await ctx.page.waitForTimeout(2_000);
+
+    const quickInput = ctx.page.locator(QUICK_INPUT);
+    await expect(quickInput).toBeVisible();
+    await expect(quickInput.locator('input.input')).toHaveAttribute(
+        'placeholder',
+        'Select an app manifest to open',
+    );
+
+    // Both workspace manifests plus the Browse… entry should be listed.
+    const rows = quickInput.locator('.quick-input-list .monaco-list-row');
+    await expect(rows).toHaveCount(3);
+    await expect(quickInput).toContainText('Browse');
+
+    await ctx.page.keyboard.press('Escape');
+    await ctx.page.waitForTimeout(500);
+    await expect(quickInput).toBeHidden();
+});


### PR DESCRIPTION
## Problem

The **Open Manifest Editor** button in the editor title bar showed a quick pick of every manifest in the workspace, even though the user was already looking at a specific manifest.

## Fix

`winapp.openManifestEditor` now accepts the `resource` URI that VS Code passes when a command is invoked from an `editor/title` menu contribution. If that URI is a manifest, it opens directly in the visual editor.

Command Palette invocations pass no argument, so the existing quick pick / Browse… flow is unchanged.

## Tests

New e2e spec `src/test/e2e/open-manifest-editor-command.spec.ts` (2 tests, own VS Code instance with two manifests in the workspace):

1. **Title bar button** — no quick pick appears, the webview opens for the active manifest, and the button disappears once the custom editor is active.
2. **Command Palette** — the quick pick appears with the `Select an app manifest to open` placeholder and lists both manifests plus the Browse… entry.

Verified the button test fails when the fix is reverted and passes with it. E2E README inventory updated.