### PR TITLE
Isolate the VS Code test harness from the user's extension install

### DIFF
--- a/.github/skills/vsce-testing/driver-extension/extension.js
+++ b/.github/skills/vsce-testing/driver-extension/extension.js
@@ -419,6 +419,7 @@ async function queryDiagnosticsStep(step, result) {
       message: d.message,
       severity: d.severity,
       source: d.source,
+      code: typeof d.code === 'object' ? d.code.value : d.code,
       start: { line: d.range.start.line, character: d.range.start.character },
       end: { line: d.range.end.line, character: d.range.end.character }
     }))

--- a/.github/skills/vsce-testing/scripts/drive-extension.ps1
+++ b/.github/skills/vsce-testing/scripts/drive-extension.ps1
@@ -69,10 +69,12 @@ if (-not $code) { throw "VS Code 'code' CLI not found on PATH." }
 
 # Fresh user-data-dir so this process inherits WINAPP_UX_SCRIPT (a reused VS Code main process would not).
 $udd = Join-Path $Harness (".udd-" + [guid]::NewGuid().ToString("N").Substring(0, 8))
+$extensionsDir = Join-Path $Harness ".drive-extensions"
+New-Item -ItemType Directory -Force -Path $extensionsDir | Out-Null
 $env:WINAPP_UX_SCRIPT = $ScriptJson
 
 Write-Host "==> [drive:$label] launching VS Code with driver extension" -ForegroundColor Cyan
-& $code --user-data-dir=$udd --disable-workspace-trust --extensionDevelopmentPath=$Driver $Project | Out-Null
+& $code "--extensions-dir=$extensionsDir" --user-data-dir=$udd --disable-workspace-trust --extensionDevelopmentPath=$Driver $Project | Out-Null
 
 $deadline = (Get-Date).AddSeconds($TimeoutSec)
 $done = $false

--- a/.github/skills/vsce-testing/scripts/install-extension.ps1
+++ b/.github/skills/vsce-testing/scripts/install-extension.ps1
@@ -37,12 +37,36 @@ $vsix = Get-ChildItem $artifacts -Filter *.vsix -ErrorAction SilentlyContinue |
 if (-not $vsix) { throw "No .vsix found in $artifacts. Build may have failed." }
 
 Write-Step "Installing extension: $($vsix.Name)"
-& code --install-extension $vsix.FullName --force
+$extensionId = "microsoft-winappcli.winapp"
+$extensionsDir = Join-Path (Split-Path $PSScriptRoot -Parent) ".drive-extensions"
+New-Item -ItemType Directory -Force -Path $extensionsDir | Out-Null
+$installedBefore = & code "--extensions-dir=$extensionsDir" --list-extensions 2>$null |
+    Where-Object { $_ -eq $extensionId }
+if ($installedBefore) {
+    Write-Step "Removing the currently registered WinApp extension to avoid stale VS Code metadata"
+    & code "--extensions-dir=$extensionsDir" --uninstall-extension $extensionId
+    if ($LASTEXITCODE -ne 0) {
+        throw "code --uninstall-extension failed with exit code $LASTEXITCODE"
+    }
+}
+
+& code "--extensions-dir=$extensionsDir" --install-extension $vsix.FullName --force
 if ($LASTEXITCODE -ne 0) { throw "code --install-extension failed with exit code $LASTEXITCODE" }
 
 Write-Step "Installed VSIX. Verifying extension is registered with VS Code:"
-$installed = & code --list-extensions --show-versions 2>$null | Select-String -Pattern 'winapp'
-if ($installed) { Write-Host $installed -ForegroundColor Green } else { Write-Warning "winapp extension not found in code --list-extensions" }
+$installed = & code "--extensions-dir=$extensionsDir" --list-extensions --show-versions 2>$null |
+    Where-Object { $_ -like "$extensionId@*" }
+if (-not $installed) {
+    throw "WinApp extension not found after installation."
+}
+
+$expectedVersion = [System.IO.Path]::GetFileNameWithoutExtension($vsix.Name) -replace '^winapp-', ''
+$installedVersion = ($installed -split '@')[-1]
+if ($installedVersion -ne $expectedVersion) {
+    throw "VS Code reports WinApp $installedVersion, but the installed VSIX is $expectedVersion. Its extension metadata cache is stale."
+}
+
+Write-Host $installed -ForegroundColor Green
 
 Write-Host "VSIX path: $($vsix.FullName)"
 return $vsix.FullName


### PR DESCRIPTION
## Why

The `vsce-testing` harness installed the locally built VSIX into the developer's *real* VS Code extensions directory and then launched VS Code against that same directory. Because VS Code keeps an extension metadata cache there, stale metadata could survive between runs — so the harness could silently drive a different build than the one it had just built. Any run that hit that case produced results that looked fine but were untrustworthy.

## What changed

- Both `scripts/install-extension.ps1` and `scripts/drive-extension.ps1` now pin `--extensions-dir` to the harness-local `.drive-extensions` directory, so the harness never touches the developer's own VS Code install.
- `install-extension.ps1` uninstalls the registered `microsoft-winappcli.winapp` extension before reinstalling, so VS Code cannot reuse stale metadata.
- The post-install check now asserts that the version VS Code reports back equals the version of the VSIX that was just built.

## Behaviour change worth reviewing

The post-install check now **throws** where it previously **warned** — both when the extension is missing from `code --list-extensions` and when the reported version disagrees with the built VSIX. This is a deliberate fail-fast: a silent version mismatch invalidates every result the harness produces, so it should stop the run rather than scroll by. A previously noisy-but-passing run can now hard-fail.

## Consistency note

`.drive-extensions` was not a new concept: it was already gitignored, already documented in the skill's `README.md` and `AGENTS.md`, and `scripts/vscode-drive.psm1:184` already auto-added the flag. This just brings the two remaining scripts in line with what the rest of the harness already assumed.

## Also included

`queryDiagnostics` in the driver extension now returns the diagnostic `code`, normalized from VS Code's `{ value, target }` object form down to a scalar. Scripted steps can now assert on diagnostic codes instead of pattern-matching message text.

## Note

Extracted from #50, where these three files landed by accident alongside the WinUI XAML language-service work. Diff is exactly 3 files, +31/-4.