### PR TITLE
perf(sign): cap and tier signable artifact discovery

### DIFF
--- a/src/artifact-types.ts
+++ b/src/artifact-types.ts
@@ -6,14 +6,29 @@
  * when a new artifact type (e.g. `.appinstaller`) is added.
  */
 
+/** Highest-priority artifact extensions — the packages `winapp pack` produces. */
+export const PRIMARY_ARTIFACT_EXTENSIONS = ['msix', 'msixbundle'] as const;
+
+/** Legacy package extensions, surfaced after the primary ones. */
+export const SECONDARY_ARTIFACT_EXTENSIONS = ['appx', 'appxbundle'] as const;
+
 /** Supported artifact file extensions (without leading dot). */
-export const ARTIFACT_EXTENSIONS = ['msix', 'msixbundle', 'appx', 'appxbundle'] as const;
+export const ARTIFACT_EXTENSIONS = [
+	...PRIMARY_ARTIFACT_EXTENSIONS,
+	...SECONDARY_ARTIFACT_EXTENSIONS
+] as const;
 
 /** Extensions with leading dot (internal — used by helpers below). */
 const DOTTED_EXTENSIONS = ARTIFACT_EXTENSIONS.map((ext) => `.${ext}`);
 
 /** Glob patterns that match packaged artifacts anywhere in a directory tree. */
 export const ARTIFACT_GLOBS: string[] = ARTIFACT_EXTENSIONS.map((ext) => `**/*.${ext}`);
+
+/** Glob patterns matching only the highest-priority package extensions. */
+export const PRIMARY_ARTIFACT_GLOBS: string[] = PRIMARY_ARTIFACT_EXTENSIONS.map((ext) => `**/*.${ext}`);
+
+/** Glob patterns matching only the legacy package extensions. */
+export const SECONDARY_ARTIFACT_GLOBS: string[] = SECONDARY_ARTIFACT_EXTENSIONS.map((ext) => `**/*.${ext}`);
 
 /** File-dialog filter for MSIX/APPX packages (VS Code `showOpenDialog` format). */
 export const ARTIFACT_DIALOG_FILTER: Record<string, string[]> = {

--- a/src/artifact-types.ts
+++ b/src/artifact-types.ts
@@ -6,29 +6,14 @@
  * when a new artifact type (e.g. `.appinstaller`) is added.
  */
 
-/** Highest-priority artifact extensions — the packages `winapp pack` produces. */
-export const PRIMARY_ARTIFACT_EXTENSIONS = ['msix', 'msixbundle'] as const;
-
-/** Legacy package extensions, surfaced after the primary ones. */
-export const SECONDARY_ARTIFACT_EXTENSIONS = ['appx', 'appxbundle'] as const;
-
 /** Supported artifact file extensions (without leading dot). */
-export const ARTIFACT_EXTENSIONS = [
-	...PRIMARY_ARTIFACT_EXTENSIONS,
-	...SECONDARY_ARTIFACT_EXTENSIONS
-] as const;
+export const ARTIFACT_EXTENSIONS = ['msix', 'msixbundle', 'appx', 'appxbundle'] as const;
 
 /** Extensions with leading dot (internal — used by helpers below). */
 const DOTTED_EXTENSIONS = ARTIFACT_EXTENSIONS.map((ext) => `.${ext}`);
 
 /** Glob patterns that match packaged artifacts anywhere in a directory tree. */
 export const ARTIFACT_GLOBS: string[] = ARTIFACT_EXTENSIONS.map((ext) => `**/*.${ext}`);
-
-/** Glob patterns matching only the highest-priority package extensions. */
-export const PRIMARY_ARTIFACT_GLOBS: string[] = PRIMARY_ARTIFACT_EXTENSIONS.map((ext) => `**/*.${ext}`);
-
-/** Glob patterns matching only the legacy package extensions. */
-export const SECONDARY_ARTIFACT_GLOBS: string[] = SECONDARY_ARTIFACT_EXTENSIONS.map((ext) => `**/*.${ext}`);
 
 /** File-dialog filter for MSIX/APPX packages (VS Code `showOpenDialog` format). */
 export const ARTIFACT_DIALOG_FILTER: Record<string, string[]> = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,10 +63,18 @@ const FILE_PICKER_DETAIL = 'Open a file picker';
 /**
  * A discovered file offered in a sign QuickPick.
  *
- * The rendered fields (`label`, `description`, `detail`) are unchanged — the
- * path is still shown in full. `filePath` carries the same value as a payload
- * so the caller can identify the "Browse…" entry by its absence, rather than
- * string-matching against `detail`.
+ * Rows carry `label` (filename) + `description` (directory relative to the
+ * workspace) and no `detail`, matching the project picker in
+ * `project-resolver.ts`. This keeps rows at the standard single-line height:
+ * a `detail` line doubles a row from 22px to 44px, which previously let only
+ * 7 of 11 entries fit and pushed "Browse…" off screen.
+ *
+ * Dropping `detail` loses nothing — it held the absolute path, which is just
+ * the workspace root (identical on every row) joined to `description` and
+ * `label`.
+ *
+ * `filePath` carries the path as a non-rendered payload so the caller can
+ * identify the "Browse…" entry by its absence.
  */
 type SignableFileItem = vscode.QuickPickItem & { filePath?: string };
 
@@ -78,7 +86,7 @@ type SignableFileItem = vscode.QuickPickItem & { filePath?: string };
 function createBrowseItem(): SignableFileItem {
 	return {
 		label: '$(folder-opened) Browse…',
-		detail: FILE_PICKER_DETAIL
+		description: FILE_PICKER_DETAIL
 	};
 }
 
@@ -422,7 +430,6 @@ async function pickSignableFile(workspacePath: string): Promise<string | undefin
 		return {
 			label: path.basename(p),
 			description: relDir === '.' ? '' : relDir,
-			detail: p,
 			filePath: p
 		};
 	});
@@ -477,7 +484,6 @@ async function pickCertificateFile(workspacePath: string): Promise<string | unde
 		return {
 			label: path.basename(p),
 			description: relDir === '.' ? '' : relDir,
-			detail: p,
 			filePath: p
 		};
 	});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,10 +61,19 @@ const WINDOWS_POWERSHELL_PATH = resolveWindowsPowerShellPath(process.env.SystemR
 const FILE_PICKER_DETAIL = 'Open a file picker';
 
 /**
- * Build the trailing "Browse…" QuickPick entry, which reaches anything the
- * capped discovery list omits.
+ * A discovered file offered in a sign QuickPick. The path travels in
+ * `filePath` rather than `detail` so rows stay single-line and the trailing
+ * "Browse…" entry is visible without scrolling — matching the folder and
+ * manifest pickers elsewhere in this file.
  */
-function createBrowseItem(): vscode.QuickPickItem {
+type SignableFileItem = vscode.QuickPickItem & { filePath?: string };
+
+/**
+ * Build the trailing "Browse…" QuickPick entry, which reaches anything the
+ * capped discovery list omits. It carries no `filePath`, which is how the
+ * caller distinguishes it from a discovered file.
+ */
+function createBrowseItem(): SignableFileItem {
 	return {
 		label: '$(folder-opened) Browse…',
 		detail: FILE_PICKER_DETAIL
@@ -406,12 +415,12 @@ async function pickSignableFile(workspacePath: string): Promise<string | undefin
 		});
 	}
 
-	const items: vscode.QuickPickItem[] = artifactPaths.map((p) => {
+	const items: SignableFileItem[] = artifactPaths.map((p) => {
 		const relDir = path.dirname(path.relative(workspacePath, p));
 		return {
 			label: path.basename(p),
 			description: relDir === '.' ? '' : relDir,
-			detail: p
+			filePath: p
 		};
 	});
 
@@ -425,7 +434,7 @@ async function pickSignableFile(workspacePath: string): Promise<string | undefin
 		return undefined;
 	}
 
-	if (picked.detail === FILE_PICKER_DETAIL) {
+	if (!picked.filePath) {
 		return selectFile('Select file to sign', {
 			...ARTIFACT_DIALOG_FILTER,
 			'Executables': ['exe', 'dll'],
@@ -433,7 +442,7 @@ async function pickSignableFile(workspacePath: string): Promise<string | undefin
 		});
 	}
 
-	return picked.detail;
+	return picked.filePath;
 }
 
 /**
@@ -460,12 +469,12 @@ async function pickCertificateFile(workspacePath: string): Promise<string | unde
 		});
 	}
 
-	const items: vscode.QuickPickItem[] = certPaths.map((p) => {
+	const items: SignableFileItem[] = certPaths.map((p) => {
 		const relDir = path.dirname(path.relative(workspacePath, p));
 		return {
 			label: path.basename(p),
 			description: relDir === '.' ? '' : relDir,
-			detail: p
+			filePath: p
 		};
 	});
 
@@ -479,13 +488,13 @@ async function pickCertificateFile(workspacePath: string): Promise<string | unde
 		return undefined;
 	}
 
-	if (picked.detail === FILE_PICKER_DETAIL) {
+	if (!picked.filePath) {
 		return selectFile('Select signing certificate', {
 			'Certificates': ['pfx']
 		});
 	}
 
-	return picked.detail;
+	return picked.filePath;
 }
 
 async function findWorkspaceArtifactsWithCancellation(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,8 +27,8 @@ import {
 import {
 	findWorkspaceArtifactsByTier,
 	buildSignCommand,
+	createWorkspaceFileFinder,
 	CERTIFICATE_GLOBS,
-	MAX_QUICKPICK_RESULTS,
 	SIGNABLE_ARTIFACT_TIERS,
 	executeSignFlow,
 	type SignFlowAdapter
@@ -58,17 +58,15 @@ import {
 
 const WINAPP_DEBUG_TYPE = 'winapp';
 const WINDOWS_POWERSHELL_PATH = resolveWindowsPowerShellPath(process.env.SystemRoot);
-const MAX_SIGNABLE_FILES = MAX_QUICKPICK_RESULTS;
 const FILE_PICKER_DETAIL = 'Open a file picker';
 
 /**
- * Build the trailing "Browse…" QuickPick entry. Discovery is capped, so when the
- * list is full the entry advertises itself as the way to reach older artifacts.
+ * Build the trailing "Browse…" QuickPick entry, which reaches anything the
+ * capped discovery list omits.
  */
-function createBrowseItem(truncated: boolean): vscode.QuickPickItem {
+function createBrowseItem(): vscode.QuickPickItem {
 	return {
 		label: '$(folder-opened) Browse…',
-		description: truncated ? `Showing the ${MAX_SIGNABLE_FILES} most recent` : undefined,
 		detail: FILE_PICKER_DETAIL
 	};
 }
@@ -383,8 +381,8 @@ async function runWinappCapture(
  * Search the workspace for signable packages, executables, and libraries and
  * let the user pick one via
  * a QuickPick. Discovery is tiered and capped: MSIX packages are searched
- * first, then legacy APPX packages, then executables and libraries, stopping as
- * soon as {@link MAX_SIGNABLE_FILES} files are found. When no artifacts are
+ * first, then remaining package types, then executables and libraries, stopping
+ * as soon as the QuickPick result cap is reached. When no artifacts are
  * found the function falls back directly to a native file dialog; a "Browse…"
  * entry is always appended so the user can reach anything the capped list omits.
  *
@@ -417,7 +415,7 @@ async function pickSignableFile(workspacePath: string): Promise<string | undefin
 		};
 	});
 
-	items.push(createBrowseItem(artifactPaths.length >= MAX_SIGNABLE_FILES));
+	items.push(createBrowseItem());
 
 	const picked = await vscode.window.showQuickPick(items, {
 		placeHolder: 'Select a file to sign'
@@ -440,8 +438,8 @@ async function pickSignableFile(workspacePath: string): Promise<string | undefin
 
 /**
  * Search the workspace for PFX certificate files and let the user pick one
- * via a QuickPick. Discovery is capped to the {@link MAX_SIGNABLE_FILES} newest
- * certificates. Falls back to a native file dialog when none are found;
+ * via a QuickPick. Discovery is capped to the newest certificates. Falls back
+ * to a native file dialog when none are found;
  * a "Browse…" entry is always appended.
  *
  * @returns The selected certificate path, or `undefined` if cancelled.
@@ -471,7 +469,7 @@ async function pickCertificateFile(workspacePath: string): Promise<string | unde
 		};
 	});
 
-	items.push(createBrowseItem(certPaths.length >= MAX_SIGNABLE_FILES));
+	items.push(createBrowseItem());
 
 	const picked = await vscode.window.showQuickPick(items, {
 		placeHolder: 'Select a signing certificate'
@@ -504,17 +502,11 @@ async function findWorkspaceArtifactsWithCancellation(
 	try {
 		const paths = await findWorkspaceArtifactsByTier(
 			workspacePath,
-			async (includePattern, search) => {
-				const matches = await vscode.workspace.findFiles(
-					new vscode.RelativePattern(workspacePath, includePattern),
-					// `null` (not a pattern) so the user's `files.exclude` setting
-					// cannot hide their own package output from the picker.
-					null,
-					search.maxResults,
-					token
-				);
-				return matches.map(uri => uri.fsPath);
-			},
+			createWorkspaceFileFinder(
+				includePattern => new vscode.RelativePattern(workspacePath, includePattern),
+				(include, exclude, maxResults) => vscode.workspace.findFiles(include, exclude, maxResults, token),
+				uri => uri.fsPath
+			),
 			tiers,
 			abortController.signal
 		);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,20 +61,9 @@ const WINDOWS_POWERSHELL_PATH = resolveWindowsPowerShellPath(process.env.SystemR
 const FILE_PICKER_DETAIL = 'Open a file picker';
 
 /**
- * A discovered file offered in a sign QuickPick.
- *
- * Rows carry `label` (filename) + `description` (directory relative to the
- * workspace) and no `detail`, matching the project picker in
- * `project-resolver.ts`. This keeps rows at the standard single-line height:
- * a `detail` line doubles a row from 22px to 44px, which previously let only
- * 7 of 11 entries fit and pushed "Browse…" off screen.
- *
- * Dropping `detail` loses nothing — it held the absolute path, which is just
- * the workspace root (identical on every row) joined to `description` and
- * `label`.
- *
- * `filePath` carries the path as a non-rendered payload so the caller can
- * identify the "Browse…" entry by its absence.
+ * A file offered in a sign QuickPick. No `detail` — that second line would
+ * double row height and only repeat the workspace root already implied by
+ * `description`. `filePath` is a non-rendered payload; "Browse…" omits it.
  */
 type SignableFileItem = vscode.QuickPickItem & { filePath?: string };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ import {
 	buildSignCommand,
 	CERTIFICATE_GLOBS,
 	EXECUTABLE_GLOBS,
+	MAX_QUICKPICK_RESULTS,
 	executeSignFlow,
 	type SignFlowAdapter
 } from './sign-utils';
@@ -57,7 +58,20 @@ import {
 
 const WINAPP_DEBUG_TYPE = 'winapp';
 const WINDOWS_POWERSHELL_PATH = resolveWindowsPowerShellPath(process.env.SystemRoot);
-const MAX_SIGNABLE_FILES = 10;
+const MAX_SIGNABLE_FILES = MAX_QUICKPICK_RESULTS;
+const FILE_PICKER_DETAIL = 'Open a file picker';
+
+/**
+ * Build the trailing "Browse…" QuickPick entry. Discovery is capped, so when the
+ * list is full the entry advertises itself as the way to reach older artifacts.
+ */
+function createBrowseItem(truncated: boolean): vscode.QuickPickItem {
+	return {
+		label: '$(folder-opened) Browse…',
+		description: truncated ? `Showing the ${MAX_SIGNABLE_FILES} most recent` : undefined,
+		detail: FILE_PICKER_DETAIL
+	};
+}
 
 /**
  * Output channel for debugger-related activity (e.g. auto-installed extensions),
@@ -368,9 +382,11 @@ async function runWinappCapture(
 /**
  * Search the workspace for signable packages, executables, and libraries and
  * let the user pick one via
- * a QuickPick. When no artifacts are found the function falls back directly to
- * a native file dialog; a "Browse…" entry is always appended so the user can
- * opt into the dialog even when artifacts *are* discovered.
+ * a QuickPick. Discovery is capped so large workspaces are not fully scanned;
+ * at most {@link MAX_SIGNABLE_FILES} newest artifacts are listed. When no
+ * artifacts are found the function falls back directly to a native file dialog;
+ * a "Browse…" entry is always appended so the user can reach anything the
+ * capped list omits.
  *
  * @returns The selected file path, or `undefined` if cancelled.
  */
@@ -411,7 +427,7 @@ async function pickSignableFile(workspacePath: string): Promise<string | undefin
 		};
 	});
 
-	items.push({ label: '$(folder-opened) Browse…', detail: 'Open a file picker' });
+	items.push(createBrowseItem(artifactPaths.length >= MAX_SIGNABLE_FILES));
 
 	const picked = await vscode.window.showQuickPick(items, {
 		placeHolder: 'Select a file to sign'
@@ -421,7 +437,7 @@ async function pickSignableFile(workspacePath: string): Promise<string | undefin
 		return undefined;
 	}
 
-	if (picked.detail === 'Open a file picker') {
+	if (picked.detail === FILE_PICKER_DETAIL) {
 		return selectFile('Select file to sign', {
 			...ARTIFACT_DIALOG_FILTER,
 			'Executables': ['exe', 'dll'],
@@ -434,7 +450,8 @@ async function pickSignableFile(workspacePath: string): Promise<string | undefin
 
 /**
  * Search the workspace for PFX certificate files and let the user pick one
- * via a QuickPick. Falls back to a native file dialog when none are found;
+ * via a QuickPick. Discovery is capped to the {@link MAX_SIGNABLE_FILES} newest
+ * certificates. Falls back to a native file dialog when none are found;
  * a "Browse…" entry is always appended.
  *
  * @returns The selected certificate path, or `undefined` if cancelled.
@@ -464,7 +481,7 @@ async function pickCertificateFile(workspacePath: string): Promise<string | unde
 		};
 	});
 
-	items.push({ label: '$(folder-opened) Browse…', detail: 'Open a file picker' });
+	items.push(createBrowseItem(certPaths.length >= MAX_SIGNABLE_FILES));
 
 	const picked = await vscode.window.showQuickPick(items, {
 		placeHolder: 'Select a signing certificate'
@@ -474,7 +491,7 @@ async function pickCertificateFile(workspacePath: string): Promise<string | unde
 		return undefined;
 	}
 
-	if (picked.detail === 'Open a file picker') {
+	if (picked.detail === FILE_PICKER_DETAIL) {
 		return selectFile('Select signing certificate', {
 			'Certificates': ['pfx']
 		});
@@ -497,11 +514,11 @@ async function findWorkspaceArtifactsWithCancellation(
 	try {
 		const paths = await findWorkspaceArtifacts(
 			workspacePath,
-			async includePattern => {
+			async (includePattern, search) => {
 				const matches = await vscode.workspace.findFiles(
 					new vscode.RelativePattern(workspacePath, includePattern),
-					null,
-					undefined,
+					new vscode.RelativePattern(workspacePath, search.excludePattern),
+					search.maxResults,
 					token
 				);
 				return matches.map(uri => uri.fsPath);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -507,7 +507,9 @@ async function findWorkspaceArtifactsWithCancellation(
 			async (includePattern, search) => {
 				const matches = await vscode.workspace.findFiles(
 					new vscode.RelativePattern(workspacePath, includePattern),
-					new vscode.RelativePattern(workspacePath, search.excludePattern),
+					// `null` (not a pattern) so the user's `files.exclude` setting
+					// cannot hide their own package output from the picker.
+					null,
 					search.maxResults,
 					token
 				);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,10 +61,12 @@ const WINDOWS_POWERSHELL_PATH = resolveWindowsPowerShellPath(process.env.SystemR
 const FILE_PICKER_DETAIL = 'Open a file picker';
 
 /**
- * A discovered file offered in a sign QuickPick. The path travels in
- * `filePath` rather than `detail` so rows stay single-line and the trailing
- * "Browse…" entry is visible without scrolling — matching the folder and
- * manifest pickers elsewhere in this file.
+ * A discovered file offered in a sign QuickPick.
+ *
+ * The rendered fields (`label`, `description`, `detail`) are unchanged — the
+ * path is still shown in full. `filePath` carries the same value as a payload
+ * so the caller can identify the "Browse…" entry by its absence, rather than
+ * string-matching against `detail`.
  */
 type SignableFileItem = vscode.QuickPickItem & { filePath?: string };
 
@@ -420,6 +422,7 @@ async function pickSignableFile(workspacePath: string): Promise<string | undefin
 		return {
 			label: path.basename(p),
 			description: relDir === '.' ? '' : relDir,
+			detail: p,
 			filePath: p
 		};
 	});
@@ -474,6 +477,7 @@ async function pickCertificateFile(workspacePath: string): Promise<string | unde
 		return {
 			label: path.basename(p),
 			description: relDir === '.' ? '' : relDir,
+			detail: p,
 			filePath: p
 		};
 	});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,15 +25,15 @@ import {
 	planPackCompletion
 } from './pack-result';
 import {
-	findWorkspaceArtifacts,
+	findWorkspaceArtifactsByTier,
 	buildSignCommand,
 	CERTIFICATE_GLOBS,
-	EXECUTABLE_GLOBS,
 	MAX_QUICKPICK_RESULTS,
+	SIGNABLE_ARTIFACT_TIERS,
 	executeSignFlow,
 	type SignFlowAdapter
 } from './sign-utils';
-import { ARTIFACT_DIALOG_FILTER, ARTIFACT_GLOBS } from './artifact-types';
+import { ARTIFACT_DIALOG_FILTER } from './artifact-types';
 import {
 	detectArchFromPath,
 	getMachineArch,
@@ -382,28 +382,18 @@ async function runWinappCapture(
 /**
  * Search the workspace for signable packages, executables, and libraries and
  * let the user pick one via
- * a QuickPick. Discovery is capped so large workspaces are not fully scanned;
- * at most {@link MAX_SIGNABLE_FILES} newest artifacts are listed. When no
- * artifacts are found the function falls back directly to a native file dialog;
- * a "Browse…" entry is always appended so the user can reach anything the
- * capped list omits.
+ * a QuickPick. Discovery is tiered and capped: MSIX packages are searched
+ * first, then legacy APPX packages, then executables and libraries, stopping as
+ * soon as {@link MAX_SIGNABLE_FILES} files are found. When no artifacts are
+ * found the function falls back directly to a native file dialog; a "Browse…"
+ * entry is always appended so the user can reach anything the capped list omits.
  *
  * @returns The selected file path, or `undefined` if cancelled.
  */
 async function pickSignableFile(workspacePath: string): Promise<string | undefined> {
 	const artifactPaths = await vscode.window.withProgress(
 		{ location: vscode.ProgressLocation.Notification, title: 'Searching for signable artifacts...', cancellable: true },
-		async (_progress, token) => {
-			const packagePaths = await findWorkspaceArtifactsWithCancellation(workspacePath, ARTIFACT_GLOBS, token);
-			if (!packagePaths) {
-				return undefined;
-			}
-			const executablePaths = await findWorkspaceArtifactsWithCancellation(workspacePath, EXECUTABLE_GLOBS, token);
-			if (!executablePaths) {
-				return undefined;
-			}
-			return [...packagePaths, ...executablePaths].slice(0, MAX_SIGNABLE_FILES);
-		}
+		(_progress, token) => findWorkspaceArtifactsWithCancellation(workspacePath, SIGNABLE_ARTIFACT_TIERS, token)
 	);
 
 	if (!artifactPaths) {
@@ -459,7 +449,7 @@ async function pickSignableFile(workspacePath: string): Promise<string | undefin
 async function pickCertificateFile(workspacePath: string): Promise<string | undefined> {
 	const certPaths = await vscode.window.withProgress(
 		{ location: vscode.ProgressLocation.Notification, title: 'Searching for certificates...', cancellable: true },
-		(_progress, token) => findWorkspaceArtifactsWithCancellation(workspacePath, CERTIFICATE_GLOBS, token)
+		(_progress, token) => findWorkspaceArtifactsWithCancellation(workspacePath, [CERTIFICATE_GLOBS], token)
 	);
 
 	if (!certPaths) {
@@ -502,7 +492,7 @@ async function pickCertificateFile(workspacePath: string): Promise<string | unde
 
 async function findWorkspaceArtifactsWithCancellation(
 	workspacePath: string,
-	patterns: string[],
+	tiers: string[][],
 	token: vscode.CancellationToken
 ): Promise<string[] | undefined> {
 	const abortController = new AbortController();
@@ -512,7 +502,7 @@ async function findWorkspaceArtifactsWithCancellation(
 	}
 
 	try {
-		const paths = await findWorkspaceArtifacts(
+		const paths = await findWorkspaceArtifactsByTier(
 			workspacePath,
 			async (includePattern, search) => {
 				const matches = await vscode.workspace.findFiles(
@@ -523,7 +513,7 @@ async function findWorkspaceArtifactsWithCancellation(
 				);
 				return matches.map(uri => uri.fsPath);
 			},
-			patterns,
+			tiers,
 			abortController.signal
 		);
 		return token.isCancellationRequested ? undefined : paths;

--- a/src/sign-utils.ts
+++ b/src/sign-utils.ts
@@ -11,9 +11,32 @@ export const EXECUTABLE_GLOBS = ['**/*.exe', '**/*.dll'];
 
 const SIGNABLE_ARTIFACT_IGNORES = new Set(['node_modules', '.git']);
 
+/** Glob matching directories that never contain user-authored signable output. */
+export const WORKSPACE_SEARCH_EXCLUDE_GLOB = '**/{node_modules,.git}/**';
+
+/** Maximum number of discovered files offered in a QuickPick before "Browse…". */
+export const MAX_QUICKPICK_RESULTS = 10;
+
+/**
+ * How many candidates to collect per displayed result.
+ *
+ * Discovery is capped so a huge workspace does not pay for a full recursive
+ * walk, but the cap is kept well above the display limit so the newest-first
+ * ordering the QuickPick shows stays deterministic for realistic workspaces.
+ */
+const CANDIDATE_POOL_MULTIPLIER = 10;
+
+export interface WorkspaceFileSearch {
+	/** Directories the finder should skip while walking the workspace. */
+	excludePattern: string;
+	/** Upper bound on matches to collect, or `undefined` for no bound. */
+	maxResults?: number;
+	signal?: AbortSignal;
+}
+
 export type WorkspaceFileFinder = (
 	includePattern: string,
-	signal?: AbortSignal
+	search: WorkspaceFileSearch
 ) => Promise<string[]>;
 
 /**
@@ -29,14 +52,17 @@ export function buildSignCommand(filePath: string, certPath: string): string {
 /**
  * Find files matching the given glob patterns within a workspace root.
  *
- * Results are sorted by modification time (newest first) so the most recently
- * packaged artifact appears at the top of the QuickPick.
+ * Discovery is bounded: at most `limit * CANDIDATE_POOL_MULTIPLIER` matches are
+ * collected, and only `limit` are returned. Results are sorted by modification
+ * time (newest first) so the most recently packaged artifact appears at the top
+ * of the QuickPick; callers offer a "Browse…" entry for anything beyond the cap.
  */
 export async function findWorkspaceArtifacts(
 	workspacePath: string,
 	findFiles: WorkspaceFileFinder,
 	patterns: string[] = ARTIFACT_GLOBS,
-	signal?: AbortSignal
+	signal?: AbortSignal,
+	limit: number = MAX_QUICKPICK_RESULTS
 ): Promise<string[]> {
 	if (signal?.aborted) {
 		return [];
@@ -45,7 +71,11 @@ export async function findWorkspaceArtifacts(
 	const includePattern = patterns.length === 1 ? patterns[0] : `{${patterns.join(',')}}`;
 	let results: string[];
 	try {
-		results = await findFiles(includePattern, signal);
+		results = await findFiles(includePattern, {
+			excludePattern: WORKSPACE_SEARCH_EXCLUDE_GLOB,
+			maxResults: limit > 0 ? limit * CANDIDATE_POOL_MULTIPLIER : undefined,
+			signal
+		});
 	} catch (error) {
 		if (signal?.aborted && isCancellationError(error)) {
 			return [];
@@ -71,7 +101,8 @@ export async function findWorkspaceArtifacts(
 	}
 
 	withStats.sort((a, b) => b.mtime - a.mtime);
-	return withStats.map((s) => s.path);
+	const sorted = withStats.map((s) => s.path);
+	return limit > 0 ? sorted.slice(0, limit) : sorted;
 }
 
 function isIgnoredWorkspacePath(workspacePath: string, filePath: string): boolean {

--- a/src/sign-utils.ts
+++ b/src/sign-utils.ts
@@ -1,13 +1,24 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { escapePowerShellArg } from './winapp-cli-utils';
-import { ARTIFACT_GLOBS } from './artifact-types';
+import { ARTIFACT_GLOBS, PRIMARY_ARTIFACT_GLOBS, SECONDARY_ARTIFACT_GLOBS } from './artifact-types';
 
 /** Glob patterns for PFX certificate files within a workspace. */
 export const CERTIFICATE_GLOBS = ['**/*.pfx'];
 
 /** Glob patterns for executable files that can be signed. */
 export const EXECUTABLE_GLOBS = ['**/*.exe', '**/*.dll'];
+
+/**
+ * Signable file globs in QuickPick priority order: MSIX packages first, then
+ * legacy APPX packages, then loose executables and libraries. Lower tiers are
+ * only searched when higher tiers leave slots unfilled.
+ */
+export const SIGNABLE_ARTIFACT_TIERS: string[][] = [
+	PRIMARY_ARTIFACT_GLOBS,
+	SECONDARY_ARTIFACT_GLOBS,
+	EXECUTABLE_GLOBS
+];
 
 const SIGNABLE_ARTIFACT_IGNORES = new Set(['node_modules', '.git']);
 
@@ -18,13 +29,13 @@ export const WORKSPACE_SEARCH_EXCLUDE_GLOB = '**/{node_modules,.git}/**';
 export const MAX_QUICKPICK_RESULTS = 10;
 
 /**
- * How many candidates to collect per displayed result.
+ * How many candidates to collect per remaining slot.
  *
- * Discovery is capped so a huge workspace does not pay for a full recursive
- * walk, but the cap is kept well above the display limit so the newest-first
- * ordering the QuickPick shows stays deterministic for realistic workspaces.
+ * Discovery is deliberately conservative: a "Browse…" entry always backs the
+ * QuickPick, so a small overshoot is enough to keep newest-first ordering
+ * meaningful without paying for a full workspace walk.
  */
-const CANDIDATE_POOL_MULTIPLIER = 10;
+const CANDIDATE_POOL_MULTIPLIER = 2;
 
 export interface WorkspaceFileSearch {
 	/** Directories the finder should skip while walking the workspace. */
@@ -56,8 +67,7 @@ export function buildSignCommand(filePath: string, certPath: string): string {
  * collected, and only `limit` are returned. Results are sorted by modification
  * time (newest first) so the most recently packaged artifact appears at the top
  * of the QuickPick; callers offer a "Browse…" entry for anything beyond the cap.
- */
-export async function findWorkspaceArtifacts(
+ */export async function findWorkspaceArtifacts(
 	workspacePath: string,
 	findFiles: WorkspaceFileFinder,
 	patterns: string[] = ARTIFACT_GLOBS,
@@ -103,6 +113,49 @@ export async function findWorkspaceArtifacts(
 	withStats.sort((a, b) => b.mtime - a.mtime);
 	const sorted = withStats.map((s) => s.path);
 	return limit > 0 ? sorted.slice(0, limit) : sorted;
+}
+
+/**
+ * Search `tiers` in priority order, stopping as soon as `limit` files are found.
+ *
+ * Each tier is sorted newest-first independently, so higher-priority file types
+ * always rank above lower-priority ones regardless of mtime. A workspace with
+ * enough MSIX packages never pays to search for executables at all.
+ */
+export async function findWorkspaceArtifactsByTier(
+	workspacePath: string,
+	findFiles: WorkspaceFileFinder,
+	tiers: string[][],
+	signal?: AbortSignal,
+	limit: number = MAX_QUICKPICK_RESULTS
+): Promise<string[]> {
+	const collected: string[] = [];
+	const seen = new Set<string>();
+
+	for (const patterns of tiers) {
+		if (signal?.aborted || collected.length >= limit) {
+			break;
+		}
+
+		const tierResults = await findWorkspaceArtifacts(
+			workspacePath,
+			findFiles,
+			patterns,
+			signal,
+			limit - collected.length
+		);
+
+		for (const filePath of tierResults) {
+			const key = process.platform === 'win32' ? filePath.toLowerCase() : filePath;
+			if (seen.has(key)) {
+				continue;
+			}
+			seen.add(key);
+			collected.push(filePath);
+		}
+	}
+
+	return signal?.aborted ? [] : collected.slice(0, limit);
 }
 
 function isIgnoredWorkspacePath(workspacePath: string, filePath: string): boolean {

--- a/src/sign-utils.ts
+++ b/src/sign-utils.ts
@@ -44,8 +44,8 @@ export const MAX_QUICKPICK_RESULTS = 10;
 const CANDIDATE_POOL_MULTIPLIER = 4;
 
 export interface WorkspaceFileSearch {
-	/** Upper bound on matches to collect, or `undefined` for no bound. */
-	maxResults?: number;
+	/** Upper bound on matches to collect. Always set — discovery stays bounded. */
+	maxResults: number;
 	signal?: AbortSignal;
 }
 
@@ -63,7 +63,7 @@ export type WorkspaceFileFinder = (
 export type FindFilesApi<TPattern, TUri> = (
 	include: TPattern,
 	exclude: null,
-	maxResults: number | undefined
+	maxResults: number
 ) => Thenable<TUri[]>;
 
 /**
@@ -109,9 +109,10 @@ export function buildSignCommand(filePath: string, certPath: string): string {
  * excluded during it, because the only way to stop VS Code from also applying
  * the user's `files.exclude` setting is to pass no exclude at all — and users
  * commonly hide their package output folder (e.g. `AppPackages`) from the
- * explorer while still wanting to sign what is inside it. When ignored paths
- * consume a saturated candidate pool, the search is retried unbounded so those
- * artifacts are still found.
+ * explorer while still wanting to sign what is inside it. Verified against
+ * `vscode.workspace.findFiles`: passing any exclude glob empties the picker for
+ * such a workspace. The search stays bounded regardless of what it turns up;
+ * "Browse…" covers anything the pool does not reach.
  */
 export async function findWorkspaceArtifacts(
 	workspacePath: string,
@@ -127,15 +128,8 @@ export async function findWorkspaceArtifacts(
 	const includePattern = patterns.length === 1 ? patterns[0] : `{${patterns.join(',')}}`;
 	const poolSize = limit * CANDIDATE_POOL_MULTIPLIER;
 
-	let results = await search(includePattern, poolSize);
-	let candidates = results.filter((filePath) => !isIgnoredWorkspacePath(workspacePath, filePath));
-
-	// A pool filled entirely to its cap may have hidden real artifacts behind
-	// ignored ones; fall back to an unbounded search only in that rare case.
-	if (results.length >= poolSize && candidates.length < limit) {
-		results = await search(includePattern, undefined);
-		candidates = results.filter((filePath) => !isIgnoredWorkspacePath(workspacePath, filePath));
-	}
+	const results = await search(includePattern, poolSize);
+	const candidates = results.filter((filePath) => !isIgnoredWorkspacePath(workspacePath, filePath));
 
 	// Sort by mtime descending (newest first); if stat fails, push to end.
 	const withStats: Array<{ path: string; mtime: number }> = [];
@@ -154,7 +148,9 @@ export async function findWorkspaceArtifacts(
 	withStats.sort((a, b) => b.mtime - a.mtime);
 	return withStats.map((s) => s.path).slice(0, limit);
 
-	async function search(include: string, maxResults: number | undefined): Promise<string[]> {
+	// `maxResults` is required, so discovery can never fall back to an unbounded
+	// workspace walk.
+	async function search(include: string, maxResults: number): Promise<string[]> {
 		if (signal?.aborted) {
 			return [];
 		}

--- a/src/sign-utils.ts
+++ b/src/sign-utils.ts
@@ -22,9 +22,6 @@ export const SIGNABLE_ARTIFACT_TIERS: string[][] = [
 
 const SIGNABLE_ARTIFACT_IGNORES = new Set(['node_modules', '.git']);
 
-/** Glob matching directories that never contain user-authored signable output. */
-export const WORKSPACE_SEARCH_EXCLUDE_GLOB = '**/{node_modules,.git}/**';
-
 /** Maximum number of discovered files offered in a QuickPick before "Browse…". */
 export const MAX_QUICKPICK_RESULTS = 10;
 
@@ -35,11 +32,9 @@ export const MAX_QUICKPICK_RESULTS = 10;
  * QuickPick, so a small overshoot is enough to keep newest-first ordering
  * meaningful without paying for a full workspace walk.
  */
-const CANDIDATE_POOL_MULTIPLIER = 2;
+const CANDIDATE_POOL_MULTIPLIER = 4;
 
 export interface WorkspaceFileSearch {
-	/** Directories the finder should skip while walking the workspace. */
-	excludePattern: string;
 	/** Upper bound on matches to collect, or `undefined` for no bound. */
 	maxResults?: number;
 	signal?: AbortSignal;
@@ -67,7 +62,16 @@ export function buildSignCommand(filePath: string, certPath: string): string {
  * collected, and only `limit` are returned. Results are sorted by modification
  * time (newest first) so the most recently packaged artifact appears at the top
  * of the QuickPick; callers offer a "Browse…" entry for anything beyond the cap.
- */export async function findWorkspaceArtifacts(
+ *
+ * `node_modules` / `.git` matches are filtered out after the search rather than
+ * excluded during it, because the only way to stop VS Code from also applying
+ * the user's `files.exclude` setting is to pass no exclude at all — and users
+ * commonly hide their package output folder (e.g. `AppPackages`) from the
+ * explorer while still wanting to sign what is inside it. When ignored paths
+ * consume a saturated candidate pool, the search is retried unbounded so those
+ * artifacts are still found.
+ */
+export async function findWorkspaceArtifacts(
 	workspacePath: string,
 	findFiles: WorkspaceFileFinder,
 	patterns: string[] = ARTIFACT_GLOBS,
@@ -79,28 +83,23 @@ export function buildSignCommand(filePath: string, certPath: string): string {
 	}
 
 	const includePattern = patterns.length === 1 ? patterns[0] : `{${patterns.join(',')}}`;
-	let results: string[];
-	try {
-		results = await findFiles(includePattern, {
-			excludePattern: WORKSPACE_SEARCH_EXCLUDE_GLOB,
-			maxResults: limit > 0 ? limit * CANDIDATE_POOL_MULTIPLIER : undefined,
-			signal
-		});
-	} catch (error) {
-		if (signal?.aborted && isCancellationError(error)) {
-			return [];
-		}
-		throw error;
+	const poolSize = limit > 0 ? limit * CANDIDATE_POOL_MULTIPLIER : undefined;
+
+	let results = await search(includePattern, poolSize);
+	let candidates = results.filter((filePath) => !isIgnoredWorkspacePath(workspacePath, filePath));
+
+	// A pool filled entirely to its cap may have hidden real artifacts behind
+	// ignored ones; fall back to an unbounded search only in that rare case.
+	if (poolSize !== undefined && results.length >= poolSize && candidates.length < limit) {
+		results = await search(includePattern, undefined);
+		candidates = results.filter((filePath) => !isIgnoredWorkspacePath(workspacePath, filePath));
 	}
 
 	// Sort by mtime descending (newest first); if stat fails, push to end.
 	const withStats: Array<{ path: string; mtime: number }> = [];
-	for (const filePath of results) {
+	for (const filePath of candidates) {
 		if (signal?.aborted) {
 			return [];
-		}
-		if (isIgnoredWorkspacePath(workspacePath, filePath)) {
-			continue;
 		}
 		try {
 			const stat = await fs.promises.stat(filePath);
@@ -113,6 +112,20 @@ export function buildSignCommand(filePath: string, certPath: string): string {
 	withStats.sort((a, b) => b.mtime - a.mtime);
 	const sorted = withStats.map((s) => s.path);
 	return limit > 0 ? sorted.slice(0, limit) : sorted;
+
+	async function search(include: string, maxResults: number | undefined): Promise<string[]> {
+		if (signal?.aborted) {
+			return [];
+		}
+		try {
+			return await findFiles(include, { maxResults, signal });
+		} catch (error) {
+			if (signal?.aborted && isCancellationError(error)) {
+				return [];
+			}
+			throw error;
+		}
+	}
 }
 
 /**

--- a/src/sign-utils.ts
+++ b/src/sign-utils.ts
@@ -10,18 +10,18 @@ export const CERTIFICATE_GLOBS = ['**/*.pfx'];
 export const EXECUTABLE_GLOBS = ['**/*.exe', '**/*.dll'];
 
 /**
- * Package extensions the QuickPick surfaces first — what `winapp pack` produces.
- * Everything else in {@link ARTIFACT_EXTENSIONS} falls into the tier below, so
- * adding a new artifact type there is still discoverable without edits here.
+ * Package extensions the QuickPick surfaces first. Everything else in
+ * {@link ARTIFACT_EXTENSIONS} falls into the tier below, so a new artifact
+ * type stays discoverable without edits here.
  */
 const PRIMARY_PACKAGE_EXTENSIONS: ReadonlySet<string> = new Set(['msix', 'msixbundle']);
 
 const toGlobs = (extensions: readonly string[]): string[] => extensions.map((ext) => `**/*.${ext}`);
 
 /**
- * Signable file globs in QuickPick priority order: MSIX packages first, then
- * remaining package types, then loose executables and libraries. Lower tiers are
- * only searched when higher tiers leave slots unfilled.
+ * Signable globs in QuickPick priority order: MSIX packages, other package
+ * types, then loose executables. Lower tiers are searched only when higher
+ * ones leave slots unfilled.
  */
 export const SIGNABLE_ARTIFACT_TIERS: string[][] = [
 	toGlobs(ARTIFACT_EXTENSIONS.filter((ext) => PRIMARY_PACKAGE_EXTENSIONS.has(ext))),
@@ -35,11 +35,9 @@ const SIGNABLE_ARTIFACT_IGNORES = new Set(['node_modules', '.git']);
 export const MAX_QUICKPICK_RESULTS = 10;
 
 /**
- * How many candidates to collect per remaining slot.
- *
- * Discovery is deliberately conservative: a "Browse…" entry always backs the
- * QuickPick, so a small overshoot is enough to keep newest-first ordering
- * meaningful without paying for a full workspace walk.
+ * Candidates to collect per remaining slot. A "Browse…" entry always backs the
+ * QuickPick, so a small overshoot keeps newest-first ordering meaningful
+ * without paying for a full workspace walk.
  */
 const CANDIDATE_POOL_MULTIPLIER = 4;
 
@@ -56,9 +54,8 @@ export type WorkspaceFileFinder = (
 
 /**
  * The subset of `vscode.workspace.findFiles` that artifact discovery uses.
- *
- * `exclude` is typed as `null` rather than `vscode.GlobPattern | null` on
- * purpose — see {@link createWorkspaceFileFinder}.
+ * `exclude` is typed `null` rather than `GlobPattern | null` on purpose — see
+ * {@link createWorkspaceFileFinder}.
  */
 export type FindFilesApi<TPattern, TUri> = (
 	include: TPattern,
@@ -67,14 +64,9 @@ export type FindFilesApi<TPattern, TUri> = (
 ) => Thenable<TUri[]>;
 
 /**
- * Adapt a `vscode.workspace.findFiles`-shaped API into a {@link WorkspaceFileFinder}.
- *
- * The `exclude` argument is pinned to `null`, and typed as `null` so a glob
- * cannot be substituted without a compile error. Passing any pattern makes VS
- * Code *additionally* apply the user's `files.exclude` setting, which silently
- * empties the sign picker for anyone who hides their package output folder
- * (e.g. `"files.exclude": { "**\/AppPackages": true }`). Ignored directories are
- * filtered after the search instead — see {@link findWorkspaceArtifacts}.
+ * Adapt a `findFiles`-shaped API into a {@link WorkspaceFileFinder}. `exclude`
+ * is pinned to `null`: any pattern makes VS Code *also* apply `files.exclude`,
+ * emptying the picker for anyone hiding their package output folder.
  */
 export function createWorkspaceFileFinder<TPattern, TUri>(
 	toPattern: (includePattern: string) => TPattern,
@@ -98,21 +90,9 @@ export function buildSignCommand(filePath: string, certPath: string): string {
 }
 
 /**
- * Find files matching the given glob patterns within a workspace root.
- *
- * Discovery is bounded: at most `limit * CANDIDATE_POOL_MULTIPLIER` matches are
- * collected, and only `limit` are returned. Results are sorted by modification
- * time (newest first) so the most recently packaged artifact appears at the top
- * of the QuickPick; callers offer a "Browse…" entry for anything beyond the cap.
- *
- * `node_modules` / `.git` matches are filtered out after the search rather than
- * excluded during it, because the only way to stop VS Code from also applying
- * the user's `files.exclude` setting is to pass no exclude at all — and users
- * commonly hide their package output folder (e.g. `AppPackages`) from the
- * explorer while still wanting to sign what is inside it. Verified against
- * `vscode.workspace.findFiles`: passing any exclude glob empties the picker for
- * such a workspace. The search stays bounded regardless of what it turns up;
- * "Browse…" covers anything the pool does not reach.
+ * Find files matching `patterns`, bounded to `limit * CANDIDATE_POOL_MULTIPLIER`
+ * matches and returning at most `limit`, newest first. `node_modules`/`.git` are
+ * filtered after the search — passing an exclude glob would apply `files.exclude`.
  */
 export async function findWorkspaceArtifacts(
 	workspacePath: string,
@@ -148,8 +128,7 @@ export async function findWorkspaceArtifacts(
 	withStats.sort((a, b) => b.mtime - a.mtime);
 	return withStats.map((s) => s.path).slice(0, limit);
 
-	// `maxResults` is required, so discovery can never fall back to an unbounded
-	// workspace walk.
+	// `maxResults` is required, so discovery can never fall back to an unbounded walk.
 	async function search(include: string, maxResults: number): Promise<string[]> {
 		if (signal?.aborted) {
 			return [];
@@ -166,11 +145,9 @@ export async function findWorkspaceArtifacts(
 }
 
 /**
- * Search `tiers` in priority order, stopping as soon as `limit` files are found.
- *
- * Each tier is sorted newest-first independently, so higher-priority file types
- * always rank above lower-priority ones regardless of mtime. A workspace with
- * enough MSIX packages never pays to search for executables at all.
+ * Search `tiers` in priority order, stopping once `limit` files are found. Each
+ * tier sorts newest-first independently, so higher-priority types always rank
+ * above lower-priority ones regardless of mtime.
  */
 export async function findWorkspaceArtifactsByTier(
 	workspacePath: string,

--- a/src/sign-utils.ts
+++ b/src/sign-utils.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { escapePowerShellArg } from './winapp-cli-utils';
-import { ARTIFACT_GLOBS, PRIMARY_ARTIFACT_GLOBS, SECONDARY_ARTIFACT_GLOBS } from './artifact-types';
+import { ARTIFACT_EXTENSIONS, ARTIFACT_GLOBS } from './artifact-types';
 
 /** Glob patterns for PFX certificate files within a workspace. */
 export const CERTIFICATE_GLOBS = ['**/*.pfx'];
@@ -10,13 +10,22 @@ export const CERTIFICATE_GLOBS = ['**/*.pfx'];
 export const EXECUTABLE_GLOBS = ['**/*.exe', '**/*.dll'];
 
 /**
+ * Package extensions the QuickPick surfaces first — what `winapp pack` produces.
+ * Everything else in {@link ARTIFACT_EXTENSIONS} falls into the tier below, so
+ * adding a new artifact type there is still discoverable without edits here.
+ */
+const PRIMARY_PACKAGE_EXTENSIONS: ReadonlySet<string> = new Set(['msix', 'msixbundle']);
+
+const toGlobs = (extensions: readonly string[]): string[] => extensions.map((ext) => `**/*.${ext}`);
+
+/**
  * Signable file globs in QuickPick priority order: MSIX packages first, then
- * legacy APPX packages, then loose executables and libraries. Lower tiers are
+ * remaining package types, then loose executables and libraries. Lower tiers are
  * only searched when higher tiers leave slots unfilled.
  */
 export const SIGNABLE_ARTIFACT_TIERS: string[][] = [
-	PRIMARY_ARTIFACT_GLOBS,
-	SECONDARY_ARTIFACT_GLOBS,
+	toGlobs(ARTIFACT_EXTENSIONS.filter((ext) => PRIMARY_PACKAGE_EXTENSIONS.has(ext))),
+	toGlobs(ARTIFACT_EXTENSIONS.filter((ext) => !PRIMARY_PACKAGE_EXTENSIONS.has(ext))),
 	EXECUTABLE_GLOBS
 ];
 
@@ -44,6 +53,39 @@ export type WorkspaceFileFinder = (
 	includePattern: string,
 	search: WorkspaceFileSearch
 ) => Promise<string[]>;
+
+/**
+ * The subset of `vscode.workspace.findFiles` that artifact discovery uses.
+ *
+ * `exclude` is typed as `null` rather than `vscode.GlobPattern | null` on
+ * purpose — see {@link createWorkspaceFileFinder}.
+ */
+export type FindFilesApi<TPattern, TUri> = (
+	include: TPattern,
+	exclude: null,
+	maxResults: number | undefined
+) => Thenable<TUri[]>;
+
+/**
+ * Adapt a `vscode.workspace.findFiles`-shaped API into a {@link WorkspaceFileFinder}.
+ *
+ * The `exclude` argument is pinned to `null`, and typed as `null` so a glob
+ * cannot be substituted without a compile error. Passing any pattern makes VS
+ * Code *additionally* apply the user's `files.exclude` setting, which silently
+ * empties the sign picker for anyone who hides their package output folder
+ * (e.g. `"files.exclude": { "**\/AppPackages": true }`). Ignored directories are
+ * filtered after the search instead — see {@link findWorkspaceArtifacts}.
+ */
+export function createWorkspaceFileFinder<TPattern, TUri>(
+	toPattern: (includePattern: string) => TPattern,
+	findFiles: FindFilesApi<TPattern, TUri>,
+	toPath: (uri: TUri) => string
+): WorkspaceFileFinder {
+	return async (includePattern, search) => {
+		const matches = await findFiles(toPattern(includePattern), null, search.maxResults);
+		return matches.map(toPath);
+	};
+}
 
 /**
  * Build the CLI argument string for `winapp sign`.
@@ -78,19 +120,19 @@ export async function findWorkspaceArtifacts(
 	signal?: AbortSignal,
 	limit: number = MAX_QUICKPICK_RESULTS
 ): Promise<string[]> {
-	if (signal?.aborted) {
+	if (signal?.aborted || limit <= 0) {
 		return [];
 	}
 
 	const includePattern = patterns.length === 1 ? patterns[0] : `{${patterns.join(',')}}`;
-	const poolSize = limit > 0 ? limit * CANDIDATE_POOL_MULTIPLIER : undefined;
+	const poolSize = limit * CANDIDATE_POOL_MULTIPLIER;
 
 	let results = await search(includePattern, poolSize);
 	let candidates = results.filter((filePath) => !isIgnoredWorkspacePath(workspacePath, filePath));
 
 	// A pool filled entirely to its cap may have hidden real artifacts behind
 	// ignored ones; fall back to an unbounded search only in that rare case.
-	if (poolSize !== undefined && results.length >= poolSize && candidates.length < limit) {
+	if (results.length >= poolSize && candidates.length < limit) {
 		results = await search(includePattern, undefined);
 		candidates = results.filter((filePath) => !isIgnoredWorkspacePath(workspacePath, filePath));
 	}
@@ -110,8 +152,7 @@ export async function findWorkspaceArtifacts(
 	}
 
 	withStats.sort((a, b) => b.mtime - a.mtime);
-	const sorted = withStats.map((s) => s.path);
-	return limit > 0 ? sorted.slice(0, limit) : sorted;
+	return withStats.map((s) => s.path).slice(0, limit);
 
 	async function search(include: string, maxResults: number | undefined): Promise<string[]> {
 		if (signal?.aborted) {

--- a/src/test/e2e/README.md
+++ b/src/test/e2e/README.md
@@ -46,7 +46,7 @@ Tests run against real AppxManifest files stored in `src/test/fixtures/`:
 
 ---
 
-## Test inventory (130 tests)
+## Test inventory (132 tests)
 
 ### `sign-quickpick.spec.ts` — 8 tests
 
@@ -56,7 +56,7 @@ Validates that `winapp.sign` discovers signable files and certificates in worksp
 |---|------|-----------|
 | 1 | shows QuickPick with .msix file and Browse option when artifacts exist | QuickPick appears with artifact rows and Browse… fallback |
 | 2 | shows packages before executables and limits discovered files to 10 | Package-first ordering and the discovery cap |
-| 3 | ranks MSIX packages above newer APPX packages and executables | Tier order beats mtime, and Browse omits the truncation note when nothing was cut |
+| 3 | ranks MSIX packages above newer APPX packages and executables | Tier order beats mtime, and Browse appears after the ranked results |
 | 4 | ignores files.exclude without showing dependency artifacts | `files.exclude` cannot hide signable output, while `node_modules` stays filtered |
 | 5 | shows certificate QuickPick with .pfx file after selecting a package | Certificate QuickPick appears after package selection with .pfx rows and Browse… fallback |
 | 6 | cancelling the artifact QuickPick aborts the sign flow | Cancelling before file selection stops signing |

--- a/src/test/e2e/README.md
+++ b/src/test/e2e/README.md
@@ -48,7 +48,7 @@ Tests run against real AppxManifest files stored in `src/test/fixtures/`:
 
 ## Test inventory (130 tests)
 
-### `sign-quickpick.spec.ts` — 6 tests
+### `sign-quickpick.spec.ts` — 8 tests
 
 Validates that `winapp.sign` discovers signable files and certificates in workspace QuickPicks.
 
@@ -56,10 +56,12 @@ Validates that `winapp.sign` discovers signable files and certificates in worksp
 |---|------|-----------|
 | 1 | shows QuickPick with .msix file and Browse option when artifacts exist | QuickPick appears with artifact rows and Browse… fallback |
 | 2 | shows packages before executables and limits discovered files to 10 | Package-first ordering and the discovery cap |
-| 3 | shows certificate QuickPick with .pfx file after selecting a package | Certificate QuickPick appears after package selection with .pfx rows and Browse… fallback |
-| 4 | cancelling the artifact QuickPick aborts the sign flow | Cancelling before file selection stops signing |
-| 5 | selecting Browse dismisses the QuickPick in a native-dialog smoke test | Browse hands off to the native file picker |
-| 6 | cancelling the certificate QuickPick aborts the sign flow | Cancelling before certificate selection stops signing |
+| 3 | ranks MSIX packages above newer APPX packages and executables | Tier order beats mtime, and Browse omits the truncation note when nothing was cut |
+| 4 | ignores files.exclude without showing dependency artifacts | `files.exclude` cannot hide signable output, while `node_modules` stays filtered |
+| 5 | shows certificate QuickPick with .pfx file after selecting a package | Certificate QuickPick appears after package selection with .pfx rows and Browse… fallback |
+| 6 | cancelling the artifact QuickPick aborts the sign flow | Cancelling before file selection stops signing |
+| 7 | selecting Browse dismisses the QuickPick in a native-dialog smoke test | Browse hands off to the native file picker |
+| 8 | cancelling the certificate QuickPick aborts the sign flow | Cancelling before certificate selection stops signing |
 
 ### `input-folder-validation.spec.ts` — 1 test
 

--- a/src/test/e2e/sign-quickpick.spec.ts
+++ b/src/test/e2e/sign-quickpick.spec.ts
@@ -23,7 +23,7 @@
  *   Escape on the certificate QuickPick. Verifies the sign flow aborts (no terminal).
  */
 
-import { test, expect, _electron as electron, type ElectronApplication, type Page } from '@playwright/test';
+import { test, expect, _electron as electron, type ElectronApplication, type Locator, type Page } from '@playwright/test';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -75,6 +75,25 @@ async function runCommandPalette(page: Page, commandLabel: string): Promise<void
     await page.keyboard.type(commandLabel, { delay: 30 });
     await page.waitForTimeout(1_500);
     await page.keyboard.press('Enter');
+}
+
+/**
+ * Wait for a command's own QuickPick to replace the Command Palette.
+ *
+ * Pressing Enter does not close the palette synchronously: it stays on screen,
+ * rows and all, until the command opens its QuickPick. Waiting on "any list row
+ * is visible" is therefore satisfied immediately by *palette* rows, and any
+ * one-shot read that follows races the transition — returning palette content.
+ *
+ * The placeholder is unique per picker, so poll on that instead and only then
+ * touch the rows.
+ */
+async function waitForQuickPick(page: Page, placeholder: RegExp): Promise<Locator> {
+    const quickInput = page.locator('.quick-input-widget');
+    await expect(
+        quickInput.locator('.quick-input-filter input[type="text"]')
+    ).toHaveAttribute('placeholder', placeholder, { timeout: 20_000 });
+    return quickInput;
 }
 
 /**
@@ -136,20 +155,8 @@ test.describe('winapp.sign command — artifact discovery', () => {
             // Run "WinApp: Sign File"
             await runCommandPalette(page, 'WinApp: Sign File');
 
-            // The QuickPick should appear. Wait for the quick-input widget to
-            // become visible. VS Code keeps the widget in the DOM with
-            // style="display:none" when inactive, so we must also exclude that.
-            const quickInput = page.locator('.quick-input-widget');
-            // Wait for either the quick-input list rows or the placeholder to
-            // appear — this accounts for VS Code toggling visibility classes.
-            await expect(
-                quickInput.locator('.quick-input-list .monaco-list-row').first()
-            ).toBeVisible({ timeout: 20_000 });
-
-            // The placeholder text should mention signing
-            const inputBox = quickInput.locator('.quick-input-filter input[type="text"]');
-            const placeholder = await inputBox.getAttribute('placeholder');
-            expect(placeholder).toContain('file to sign');
+            // Wait for the sign picker to take over from the palette.
+            const quickInput = await waitForQuickPick(page, /file to sign/i);
 
             // There should be at least 2 items: the .msix file + Browse…
             const items = quickInput.locator('.quick-input-list .monaco-list-row');
@@ -193,7 +200,8 @@ test.describe('winapp.sign command — artifact discovery', () => {
 
             await runCommandPalette(page, 'WinApp: Sign File');
 
-            const items = page.locator('.quick-input-widget .quick-input-list .monaco-list-row');
+            const quickInput = await waitForQuickPick(page, /file to sign/i);
+            const items = quickInput.locator('.quick-input-list .monaco-list-row');
             await expect(items.first()).toBeVisible({ timeout: 20_000 });
             await expect(items.first()).toHaveAttribute('aria-setsize', '11');
 
@@ -234,7 +242,8 @@ test.describe('winapp.sign command — artifact discovery', () => {
 
             await runCommandPalette(page, 'WinApp: Sign File');
 
-            const items = page.locator('.quick-input-widget .quick-input-list .monaco-list-row');
+            const quickInput = await waitForQuickPick(page, /file to sign/i);
+            const items = quickInput.locator('.quick-input-list .monaco-list-row');
             await expect(items.first()).toBeVisible({ timeout: 20_000 });
             await expect(items.first()).toHaveAttribute('aria-setsize', '4');
 
@@ -268,9 +277,7 @@ test.describe('winapp.sign command — artifact discovery', () => {
 
             await runCommandPalette(page, 'WinApp: Sign File');
 
-            const quickInput = page.locator('.quick-input-widget');
-            const inputBox = quickInput.locator('.quick-input-filter input[type="text"]');
-            await expect(inputBox).toHaveAttribute('placeholder', /file to sign/, { timeout: 20_000 });
+            const quickInput = await waitForQuickPick(page, /file to sign/i);
             const itemText = await quickInput.locator('.quick-input-list .monaco-list-row').allTextContents();
             expect(itemText.join(' ')).toContain('MyApp_1.0.0.0_x64.msix');
             expect(itemText.join(' ')).not.toContain('Ignored.msix');
@@ -296,29 +303,14 @@ test.describe('winapp.sign command — artifact discovery', () => {
             // Run "WinApp: Sign File"
             await runCommandPalette(page, 'WinApp: Sign File');
 
-            // Wait for the artifact QuickPick to appear
-            const quickInput = page.locator('.quick-input-widget');
-            await expect(
-                quickInput.locator('.quick-input-list .monaco-list-row').first()
-            ).toBeVisible({ timeout: 20_000 });
-
-            // Verify it's the package picker
-            const packageInput = quickInput.locator('.quick-input-filter input[type="text"]');
-            const packagePlaceholder = await packageInput.getAttribute('placeholder');
-            expect(packagePlaceholder).toContain('file to sign');
+            // Wait for the artifact QuickPick to take over from the palette
+            const quickInput = await waitForQuickPick(page, /file to sign/i);
 
             // Select the .msix artifact (first item) to advance to cert picker
             await quickInput.locator('.quick-input-list .monaco-list-row').first().click();
 
-            // Wait for the certificate QuickPick to appear (second picker)
-            await expect(
-                quickInput.locator('.quick-input-list .monaco-list-row').first()
-            ).toBeVisible({ timeout: 20_000 });
-
-            // The placeholder should now mention certificate
-            const certInput = quickInput.locator('.quick-input-filter input[type="text"]');
-            const certPlaceholder = await certInput.getAttribute('placeholder');
-            expect(certPlaceholder).toContain('signing certificate');
+            // Wait for the certificate QuickPick to replace it
+            await waitForQuickPick(page, /signing certificate/i);
 
             // There should be 2 items: the .pfx file + Browse…
             const certItems = quickInput.locator('.quick-input-list .monaco-list-row');
@@ -360,26 +352,18 @@ test.describe('winapp.sign command — artifact discovery', () => {
             // Run "WinApp: Sign File"
             await runCommandPalette(page, 'WinApp: Sign File');
 
-            // Wait for the artifact QuickPick to appear
-            const quickInput = page.locator('.quick-input-widget');
-            await expect(
-                quickInput.locator('.quick-input-list .monaco-list-row').first()
-            ).toBeVisible({ timeout: 20_000 });
-
-            // Verify it's the package picker
-            const inputBox = quickInput.locator('.quick-input-filter input[type="text"]');
-            const placeholder = await inputBox.getAttribute('placeholder');
-            expect(placeholder).toContain('file to sign');
+            // Wait for the artifact QuickPick to take over from the palette
+            const quickInput = await waitForQuickPick(page, /file to sign/i);
 
             // Press Escape to cancel the QuickPick
             await page.keyboard.press('Escape');
             await page.waitForTimeout(2_000);
 
-            // Verify the QuickPick is dismissed — the list rows should no longer
-            // be visible. We check that no quick-input list rows are shown, which
-            // means no second picker (certificate) appeared.
-            const visibleRows = quickInput.locator('.quick-input-list .monaco-list-row');
-            await expect(visibleRows).toHaveCount(0, { timeout: 5_000 });
+            // Verify the QuickPick is dismissed. VS Code keeps the rendered rows
+            // in the DOM after hiding the widget, so assert on widget visibility
+            // rather than row count. A hidden widget also proves no second picker
+            // (certificate) appeared.
+            await expect(quickInput).toBeHidden({ timeout: 5_000 });
 
             // Verify no WinApp terminal was created (sign was not executed)
             const terminalTabs = page.locator('.terminal-tab');
@@ -411,11 +395,9 @@ test.describe('winapp.sign command — artifact discovery', () => {
             // Run "WinApp: Sign File"
             await runCommandPalette(page, 'WinApp: Sign File');
 
-            // Wait for the artifact QuickPick to appear
-            const quickInput = page.locator('.quick-input-widget');
-            await expect(
-                quickInput.locator('.quick-input-list .monaco-list-row').first()
-            ).toBeVisible({ timeout: 20_000 });
+            // Wait for the artifact QuickPick to take over from the palette —
+            // without this, the row clicked below could be a palette command.
+            const quickInput = await waitForQuickPick(page, /file to sign/i);
 
             // Click "Browse…" (second item, the last row)
             const items = quickInput.locator('.quick-input-list .monaco-list-row');
@@ -431,9 +413,9 @@ test.describe('winapp.sign command — artifact discovery', () => {
             // VS Code-side handoff happens without an immediate error.
             await page.waitForTimeout(2_000);
 
-            // The QuickPick list should no longer be visible (replaced by native dialog)
-            const visibleRows = quickInput.locator('.quick-input-list .monaco-list-row');
-            await expect(visibleRows).toHaveCount(0, { timeout: 5_000 });
+            // The QuickPick should be dismissed (replaced by the native dialog).
+            // Rows stay in the DOM after hiding, so assert widget visibility.
+            await expect(quickInput).toBeHidden({ timeout: 5_000 });
 
             // No error notification should be visible
             const errorNotification = page.locator('.notification-toast .codicon-error');
@@ -469,32 +451,22 @@ test.describe('winapp.sign command — artifact discovery', () => {
             // Run "WinApp: Sign File"
             await runCommandPalette(page, 'WinApp: Sign File');
 
-            // Wait for the artifact QuickPick to appear
-            const quickInput = page.locator('.quick-input-widget');
-            await expect(
-                quickInput.locator('.quick-input-list .monaco-list-row').first()
-            ).toBeVisible({ timeout: 20_000 });
+            // Wait for the artifact QuickPick to take over from the palette
+            const quickInput = await waitForQuickPick(page, /file to sign/i);
 
             // Select the .msix artifact (first item) to advance to cert picker
             await quickInput.locator('.quick-input-list .monaco-list-row').first().click();
 
-            // Wait for the certificate QuickPick to appear
-            await expect(
-                quickInput.locator('.quick-input-list .monaco-list-row').first()
-            ).toBeVisible({ timeout: 20_000 });
-
-            // Verify it's the certificate picker
-            const certInput = quickInput.locator('.quick-input-filter input[type="text"]');
-            const certPlaceholder = await certInput.getAttribute('placeholder');
-            expect(certPlaceholder).toContain('signing certificate');
+            // Wait for the certificate QuickPick to replace it
+            await waitForQuickPick(page, /signing certificate/i);
 
             // Press Escape to cancel the certificate QuickPick
             await page.keyboard.press('Escape');
             await page.waitForTimeout(2_000);
 
-            // Verify the QuickPick is dismissed
-            const visibleRows = quickInput.locator('.quick-input-list .monaco-list-row');
-            await expect(visibleRows).toHaveCount(0, { timeout: 5_000 });
+            // Verify the QuickPick is dismissed. Rows remain in the DOM after
+            // hiding, so assert on widget visibility.
+            await expect(quickInput).toBeHidden({ timeout: 5_000 });
 
             // Verify no WinApp terminal was created (sign was not executed)
             const terminalTabs = page.locator('.terminal-tab');

--- a/src/test/e2e/sign-quickpick.spec.ts
+++ b/src/test/e2e/sign-quickpick.spec.ts
@@ -101,6 +101,14 @@ function createSignTestWorkspace(options?: { includePfx?: boolean; additionalFil
     return tmpDir;
 }
 
+/** Create a file with a specific modification time, for ordering assertions. */
+function createFileWithMtime(filePath: string, mtimeMs: number): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, Buffer.alloc(1024));
+    const time = new Date(mtimeMs);
+    fs.utimesSync(filePath, time, time);
+}
+
 function configureFilesExclude(workspacePath: string): void {
     const settingsPath = path.join(workspacePath, '.vscode', 'settings.json');
     fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
@@ -192,6 +200,43 @@ test.describe('winapp.sign command — artifact discovery', () => {
             const itemText = await items.allTextContents();
             expect(itemText.slice(0, 2).every(text => /\.(msix|msixbundle)/i.test(text))).toBe(true);
             expect(itemText.slice(2).every(text => /\.(exe|dll)/i.test(text))).toBe(true);
+
+            await page.keyboard.press('Escape');
+        } finally {
+            if (app) {
+                await app.close().catch(() => {});
+            }
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    test('ranks MSIX packages above newer APPX packages and executables', async () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sign-e2e-tier-'));
+        const now = Date.now();
+        // The MSIX is the oldest file, so tier order (not mtime) must decide.
+        createFileWithMtime(path.join(tmpDir, 'AppPackages', 'Packaged.msix'), now - 600_000);
+        createFileWithMtime(path.join(tmpDir, 'AppPackages', 'Legacy.appx'), now);
+        createFileWithMtime(path.join(tmpDir, 'bin', 'App.exe'), now);
+
+        let app: ElectronApplication | undefined;
+        try {
+            const launched = await launchVSCodeForFolder(tmpDir);
+            app = launched.app;
+            const page = launched.page;
+
+            await runCommandPalette(page, 'WinApp: Sign File');
+
+            const items = page.locator('.quick-input-widget .quick-input-list .monaco-list-row');
+            await expect(items.first()).toBeVisible({ timeout: 20_000 });
+            await expect(items.first()).toHaveAttribute('aria-setsize', '4');
+
+            const itemText = await items.allTextContents();
+            expect(itemText[0]).toContain('Packaged.msix');
+            expect(itemText[1]).toContain('Legacy.appx');
+            expect(itemText[2]).toContain('App.exe');
+            expect(itemText[3]).toContain('Browse');
+            // The list is not capped, so Browse should not advertise truncation.
+            expect(itemText[3]).not.toContain('most recent');
 
             await page.keyboard.press('Escape');
         } finally {

--- a/src/test/e2e/sign-quickpick.spec.ts
+++ b/src/test/e2e/sign-quickpick.spec.ts
@@ -209,10 +209,18 @@ test.describe('winapp.sign command — artifact discovery', () => {
             expect(itemText.slice(0, 2).every(text => /\.(msix|msixbundle)/i.test(text))).toBe(true);
             expect(itemText.slice(2, 10).every(text => /\.(exe|dll)/i.test(text))).toBe(true);
 
-            // The Browse row is virtualized out of view while the list is capped.
-            // ArrowUp from the first item wraps to the last, scrolling it in.
+            // Browse must be reachable without scrolling even at the cap: single-line
+            // rows keep all 11 entries on screen. Guards the layout regression where
+            // a per-item `detail` line pushed Browse out of view.
+            const rowBoxes = await items.evaluateAll((rows) =>
+                rows.map((row) => row.getBoundingClientRect().bottom));
+            const listBottom = await quickInput
+                .locator('.quick-input-list')
+                .evaluate((list) => list.getBoundingClientRect().bottom);
+            expect(rowBoxes.length).toBe(11);
+            expect(Math.max(...rowBoxes)).toBeLessThanOrEqual(listBottom + 1);
+
             // Even when capped, Browse stays plain — no count or truncation note.
-            await page.keyboard.press('ArrowUp');
             const browseRow = items.last();
             await expect(browseRow).toContainText('Browse');
             await expect(browseRow).not.toContainText(/most recent|showing/i);

--- a/src/test/e2e/sign-quickpick.spec.ts
+++ b/src/test/e2e/sign-quickpick.spec.ts
@@ -37,6 +37,13 @@ const VSCODE_EXE =
     path.join(os.homedir(), 'AppData', 'Local', 'Programs', 'Microsoft VS Code', 'Code.exe');
 
 const EXTENSION_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+/**
+ * Height of a QuickPick row carrying only `label` + `description`, which is the
+ * standard across our pickers (see `ProjectQuickPickItem` in project-resolver).
+ * Adding a `detail` line doubles this to 44px.
+ */
+const STANDARD_ROW_HEIGHT_PX = 22;
 const EXTENSION_ARGS = process.env.E2E_USE_INSTALLED_EXTENSION === '1'
     ? []
     : [`--extensionDevelopmentPath=${EXTENSION_ROOT}`];
@@ -209,11 +216,27 @@ test.describe('winapp.sign command — artifact discovery', () => {
             expect(itemText.slice(0, 2).every(text => /\.(msix|msixbundle)/i.test(text))).toBe(true);
             expect(itemText.slice(2, 10).every(text => /\.(exe|dll)/i.test(text))).toBe(true);
 
-            // The Browse row is virtualized out of view while the list is capped
-            // (rows are three lines tall, so ~7 fit). ArrowUp from the first item
-            // wraps to the last, scrolling it in.
+            // Rows must stay at the standard single-line height (as in the init
+            // project picker). A `detail` line doubles a row to 44px, at which
+            // point only 7 of 11 entries fit and "Browse…" falls off screen.
+            const layout = await quickInput.locator('.quick-input-list').evaluate((listEl) => {
+                const listBox = listEl.getBoundingClientRect();
+                const rows = Array.from(listEl.querySelectorAll('.monaco-list-row')) as (typeof listEl)[];
+                return {
+                    rowHeights: Array.from(new Set(rows.map(r => Math.round(r.getBoundingClientRect().height)))),
+                    rendered: rows.length,
+                    fullyVisible: rows.filter((r) => {
+                        const b = r.getBoundingClientRect();
+                        return b.top >= listBox.top - 1 && b.bottom <= listBox.bottom + 1;
+                    }).length,
+                };
+            });
+            expect(layout.rowHeights).toEqual([STANDARD_ROW_HEIGHT_PX]);
+            // All 11 entries render and fit, so Browse needs no scrolling.
+            expect(layout.rendered).toBe(11);
+            expect(layout.fullyVisible).toBe(11);
+
             // Even when capped, Browse stays plain — no count or truncation note.
-            await page.keyboard.press('ArrowUp');
             const browseRow = items.last();
             await expect(browseRow).toContainText('Browse');
             await expect(browseRow).not.toContainText(/most recent|showing/i);

--- a/src/test/e2e/sign-quickpick.spec.ts
+++ b/src/test/e2e/sign-quickpick.spec.ts
@@ -209,18 +209,11 @@ test.describe('winapp.sign command — artifact discovery', () => {
             expect(itemText.slice(0, 2).every(text => /\.(msix|msixbundle)/i.test(text))).toBe(true);
             expect(itemText.slice(2, 10).every(text => /\.(exe|dll)/i.test(text))).toBe(true);
 
-            // Browse must be reachable without scrolling even at the cap: single-line
-            // rows keep all 11 entries on screen. Guards the layout regression where
-            // a per-item `detail` line pushed Browse out of view.
-            const rowBoxes = await items.evaluateAll((rows) =>
-                rows.map((row) => row.getBoundingClientRect().bottom));
-            const listBottom = await quickInput
-                .locator('.quick-input-list')
-                .evaluate((list) => list.getBoundingClientRect().bottom);
-            expect(rowBoxes.length).toBe(11);
-            expect(Math.max(...rowBoxes)).toBeLessThanOrEqual(listBottom + 1);
-
+            // The Browse row is virtualized out of view while the list is capped
+            // (rows are three lines tall, so ~7 fit). ArrowUp from the first item
+            // wraps to the last, scrolling it in.
             // Even when capped, Browse stays plain — no count or truncation note.
+            await page.keyboard.press('ArrowUp');
             const browseRow = items.last();
             await expect(browseRow).toContainText('Browse');
             await expect(browseRow).not.toContainText(/most recent|showing/i);

--- a/src/test/e2e/sign-quickpick.spec.ts
+++ b/src/test/e2e/sign-quickpick.spec.ts
@@ -199,7 +199,15 @@ test.describe('winapp.sign command — artifact discovery', () => {
 
             const itemText = await items.allTextContents();
             expect(itemText.slice(0, 2).every(text => /\.(msix|msixbundle)/i.test(text))).toBe(true);
-            expect(itemText.slice(2).every(text => /\.(exe|dll)/i.test(text))).toBe(true);
+            expect(itemText.slice(2, 10).every(text => /\.(exe|dll)/i.test(text))).toBe(true);
+
+            // The Browse row is virtualized out of view while the list is capped.
+            // ArrowUp from the first item wraps to the last, scrolling it in.
+            // Even when capped, Browse stays plain — no count or truncation note.
+            await page.keyboard.press('ArrowUp');
+            const browseRow = items.last();
+            await expect(browseRow).toContainText('Browse');
+            await expect(browseRow).not.toContainText(/most recent|showing/i);
 
             await page.keyboard.press('Escape');
         } finally {
@@ -235,8 +243,6 @@ test.describe('winapp.sign command — artifact discovery', () => {
             expect(itemText[1]).toContain('Legacy.appx');
             expect(itemText[2]).toContain('App.exe');
             expect(itemText[3]).toContain('Browse');
-            // The list is not capped, so Browse should not advertise truncation.
-            expect(itemText[3]).not.toContain('most recent');
 
             await page.keyboard.press('Escape');
         } finally {

--- a/src/test/sign-utils.test.ts
+++ b/src/test/sign-utils.test.ts
@@ -8,6 +8,7 @@ import {
 	findWorkspaceArtifacts as findWorkspaceArtifactsCore,
 	findWorkspaceArtifactsByTier,
 	buildSignCommand,
+	createWorkspaceFileFinder,
 	CERTIFICATE_GLOBS,
 	EXECUTABLE_GLOBS,
 	MAX_QUICKPICK_RESULTS,
@@ -205,6 +206,31 @@ describe('findWorkspaceArtifacts', () => {
 		assert.ok(received.maxResults <= MAX_QUICKPICK_RESULTS * 4);
 	});
 
+	it('returns nothing for a zero or negative limit', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		createFile(path.join(tempDir, 'pkg.msix'));
+		let calls = 0;
+		const countingFinder = async () => {
+			calls++;
+			return [path.join(tempDir, 'pkg.msix')];
+		};
+
+		for (const limit of [0, -1]) {
+			const results = await findWorkspaceArtifactsCore(
+				tempDir,
+				countingFinder,
+				ARTIFACT_GLOBS,
+				undefined,
+				limit
+			);
+			// A non-positive cap must mean "nothing", never an unbounded walk.
+			assert.deepEqual(results, []);
+		}
+
+		assert.equal(calls, 0);
+	});
+
 	it('retries unbounded when ignored paths saturate the candidate pool', async () => {
 		const tempDir = createTempDir();
 		tempDirs.push(tempDir);
@@ -231,6 +257,34 @@ describe('findWorkspaceArtifacts', () => {
 
 		assert.deepEqual(requestedLimits, [8, undefined]);
 		assert.deepEqual(results, [real]);
+	});
+
+	it('does not run the unbounded retry after cancellation', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const ignored = Array.from({ length: 8 }, (_, index) =>
+			path.join(tempDir, 'node_modules', 'pkg', `dep${index}.msix`));
+		for (const filePath of ignored) {
+			createFile(filePath);
+		}
+		const controller = new AbortController();
+		const requestedLimits: Array<number | undefined> = [];
+
+		const results = await findWorkspaceArtifactsCore(
+			tempDir,
+			async (_includePattern, search) => {
+				requestedLimits.push(search.maxResults);
+				// Saturate the pool with ignored paths, then cancel before the retry.
+				controller.abort();
+				return ignored;
+			},
+			ARTIFACT_GLOBS,
+			controller.signal,
+			2
+		);
+
+		assert.deepEqual(requestedLimits, [8]);
+		assert.deepEqual(results, []);
 	});
 
 	it('does not retry when the candidate pool was not saturated', async () => {
@@ -367,6 +421,44 @@ describe('findWorkspaceArtifacts', () => {
 			),
 			/search failed/
 		);
+	});
+});
+
+describe('createWorkspaceFileFinder', () => {
+	it('never passes an exclude pattern to the underlying finder', async () => {
+		const excludes: unknown[] = [];
+		const finder = createWorkspaceFileFinder(
+			includePattern => includePattern,
+			async (_include, exclude, _maxResults) => {
+				excludes.push(exclude);
+				return ['C:\\ws\\AppPackages\\App.msix'];
+			},
+			uri => uri
+		);
+
+		await finder('**/*.msix', { maxResults: 40 });
+		await finder('**/*.exe', { maxResults: undefined });
+
+		// A glob here would make VS Code also apply the user's `files.exclude`,
+		// which hides their own package output and empties the sign picker.
+		assert.deepEqual(excludes, [null, null]);
+	});
+
+	it('forwards the include pattern and result cap, and maps matches to paths', async () => {
+		const calls: Array<{ include: string; maxResults: number | undefined }> = [];
+		const finder = createWorkspaceFileFinder(
+			includePattern => `rel:${includePattern}`,
+			async (include, _exclude, maxResults) => {
+				calls.push({ include, maxResults });
+				return [{ fsPath: 'C:\\ws\\App.msix' }];
+			},
+			uri => uri.fsPath
+		);
+
+		const results = await finder('**/*.msix', { maxResults: 40 });
+
+		assert.deepEqual(calls, [{ include: 'rel:**/*.msix', maxResults: 40 }]);
+		assert.deepEqual(results, ['C:\\ws\\App.msix']);
 	});
 });
 

--- a/src/test/sign-utils.test.ts
+++ b/src/test/sign-utils.test.ts
@@ -6,10 +6,12 @@ import * as path from 'node:path';
 import { glob } from 'glob';
 import {
 	findWorkspaceArtifacts as findWorkspaceArtifactsCore,
+	findWorkspaceArtifactsByTier,
 	buildSignCommand,
 	CERTIFICATE_GLOBS,
 	EXECUTABLE_GLOBS,
 	MAX_QUICKPICK_RESULTS,
+	SIGNABLE_ARTIFACT_TIERS,
 	WORKSPACE_SEARCH_EXCLUDE_GLOB,
 	type WorkspaceFileSearch
 } from '../sign-utils';
@@ -204,6 +206,7 @@ describe('findWorkspaceArtifacts', () => {
 		assert.equal(received?.excludePattern, WORKSPACE_SEARCH_EXCLUDE_GLOB);
 		assert.ok(received?.maxResults !== undefined);
 		assert.ok(received.maxResults > MAX_QUICKPICK_RESULTS);
+		assert.ok(received.maxResults <= MAX_QUICKPICK_RESULTS * 4);
 	});
 
 	it('returns only the newest results up to the limit', async () => {
@@ -318,6 +321,135 @@ describe('findWorkspaceArtifacts', () => {
 			),
 			/search failed/
 		);
+	});
+});
+
+describe('findWorkspaceArtifactsByTier', () => {
+	function findByTier(
+		workspacePath: string,
+		tiers: string[][] = SIGNABLE_ARTIFACT_TIERS,
+		signal?: AbortSignal,
+		limit?: number
+	): Promise<string[]> {
+		return findWorkspaceArtifactsByTier(
+			workspacePath,
+			(includePattern, search) => glob(includePattern, {
+				cwd: workspacePath,
+				absolute: true,
+				nodir: true,
+				ignore: search.excludePattern
+			}),
+			tiers,
+			signal,
+			limit
+		);
+	}
+
+	it('ranks MSIX packages above APPX packages and executables', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const old = Date.now() - 60_000;
+		createFile(path.join(tempDir, 'pkg.msix'), old);
+		// Newer, but lower-priority tiers must still rank below the MSIX.
+		createFile(path.join(tempDir, 'legacy.appx'), Date.now());
+		createFile(path.join(tempDir, 'app.exe'), Date.now());
+
+		const results = await findByTier(tempDir);
+
+		assert.deepEqual(
+			results.map(filePath => path.basename(filePath)),
+			['pkg.msix', 'legacy.appx', 'app.exe']
+		);
+	});
+
+	it('does not search lower tiers once the limit is reached', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const searched: string[] = [];
+
+		const results = await findWorkspaceArtifactsByTier(
+			tempDir,
+			async includePattern => {
+				searched.push(includePattern);
+				return [path.join(tempDir, 'a.msix'), path.join(tempDir, 'b.msix')];
+			},
+			SIGNABLE_ARTIFACT_TIERS,
+			undefined,
+			2
+		);
+
+		assert.equal(searched.length, 1);
+		assert.equal(results.length, 2);
+	});
+
+	it('falls through to lower tiers when higher tiers leave slots open', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		createFile(path.join(tempDir, 'app.exe'));
+		createFile(path.join(tempDir, 'app.dll'));
+
+		const results = await findByTier(tempDir);
+
+		assert.deepEqual(
+			results.map(filePath => path.basename(filePath)).sort(),
+			['app.dll', 'app.exe']
+		);
+	});
+
+	it('shrinks the per-tier limit by what earlier tiers already found', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const requestedLimits: Array<number | undefined> = [];
+
+		await findWorkspaceArtifactsByTier(
+			tempDir,
+			async (includePattern, search) => {
+				requestedLimits.push(search.maxResults);
+				return includePattern.includes('msix') ? [path.join(tempDir, 'a.msix')] : [];
+			},
+			SIGNABLE_ARTIFACT_TIERS,
+			undefined,
+			4
+		);
+
+		// Tier 1 asks for 4 slots' worth, later tiers only for the remaining 3.
+		assert.equal(requestedLimits.length, 3);
+		assert.ok(requestedLimits[0]! > requestedLimits[1]!);
+		assert.equal(requestedLimits[1], requestedLimits[2]);
+	});
+
+	it('de-duplicates files matched by more than one tier', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const duplicate = path.join(tempDir, 'a.msix');
+
+		const results = await findWorkspaceArtifactsByTier(
+			tempDir,
+			async () => [duplicate],
+			[['**/*.msix'], ['**/*.msix']],
+			undefined,
+			5
+		);
+
+		assert.deepEqual(results, [duplicate]);
+	});
+
+	it('returns nothing when cancelled mid-search', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const controller = new AbortController();
+
+		const results = await findWorkspaceArtifactsByTier(
+			tempDir,
+			async () => {
+				controller.abort();
+				return [path.join(tempDir, 'a.msix')];
+			},
+			SIGNABLE_ARTIFACT_TIERS,
+			controller.signal
+		);
+
+		assert.deepEqual(results, []);
 	});
 });
 

--- a/src/test/sign-utils.test.ts
+++ b/src/test/sign-utils.test.ts
@@ -8,7 +8,10 @@ import {
 	findWorkspaceArtifacts as findWorkspaceArtifactsCore,
 	buildSignCommand,
 	CERTIFICATE_GLOBS,
-	EXECUTABLE_GLOBS
+	EXECUTABLE_GLOBS,
+	MAX_QUICKPICK_RESULTS,
+	WORKSPACE_SEARCH_EXCLUDE_GLOB,
+	type WorkspaceFileSearch
 } from '../sign-utils';
 import { ARTIFACT_GLOBS } from '../artifact-types';
 
@@ -34,13 +37,20 @@ const tempDirs: string[] = [];
 function findWorkspaceArtifacts(
 	workspacePath: string,
 	patterns: string[] = ARTIFACT_GLOBS,
-	signal?: AbortSignal
+	signal?: AbortSignal,
+	limit?: number
 ): Promise<string[]> {
 	return findWorkspaceArtifactsCore(
 		workspacePath,
-		includePattern => glob(includePattern, { cwd: workspacePath, absolute: true, nodir: true }),
+		(includePattern, search) => glob(includePattern, {
+			cwd: workspacePath,
+			absolute: true,
+			nodir: true,
+			ignore: search.excludePattern
+		}),
 		patterns,
-		signal
+		signal,
+		limit
 	);
 }
 
@@ -175,6 +185,55 @@ describe('findWorkspaceArtifacts', () => {
 		assert.equal(receivedPattern, `{${ARTIFACT_GLOBS.join(',')}}`);
 	});
 
+	it('bounds discovery and excludes ignored directories at the finder', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		let received: WorkspaceFileSearch | undefined;
+
+		await findWorkspaceArtifactsCore(
+			tempDir,
+			async (_includePattern, search) => {
+				received = search;
+				return [];
+			},
+			ARTIFACT_GLOBS,
+			undefined,
+			MAX_QUICKPICK_RESULTS
+		);
+
+		assert.equal(received?.excludePattern, WORKSPACE_SEARCH_EXCLUDE_GLOB);
+		assert.ok(received?.maxResults !== undefined);
+		assert.ok(received.maxResults > MAX_QUICKPICK_RESULTS);
+	});
+
+	it('returns only the newest results up to the limit', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const base = Date.now();
+		for (let i = 0; i < 5; i++) {
+			createFile(path.join(tempDir, `pkg${i}.msix`), base + i * 1000);
+		}
+
+		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS, undefined, 3);
+
+		assert.deepEqual(
+			results.map(filePath => path.basename(filePath)),
+			['pkg4.msix', 'pkg3.msix', 'pkg2.msix']
+		);
+	});
+
+	it('defaults to the QuickPick result limit', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		for (let i = 0; i < MAX_QUICKPICK_RESULTS + 4; i++) {
+			createFile(path.join(tempDir, `pkg${i}.msix`), Date.now() + i * 1000);
+		}
+
+		const results = await findWorkspaceArtifacts(tempDir, ARTIFACT_GLOBS);
+
+		assert.equal(results.length, MAX_QUICKPICK_RESULTS);
+	});
+
 	it('does not start discovery when already aborted', async () => {
 		const tempDir = createTempDir();
 		tempDirs.push(tempDir);
@@ -202,8 +261,8 @@ describe('findWorkspaceArtifacts', () => {
 		const controller = new AbortController();
 		const search = findWorkspaceArtifactsCore(
 			tempDir,
-			(_includePattern, signal) => new Promise((_resolve, reject) => {
-				signal?.addEventListener('abort', () => {
+			(_includePattern, search) => new Promise((_resolve, reject) => {
+				search.signal?.addEventListener('abort', () => {
 					reject(Object.assign(new Error('Cancelled'), { name: 'Canceled' }));
 				}, { once: true });
 			}),

--- a/src/test/sign-utils.test.ts
+++ b/src/test/sign-utils.test.ts
@@ -12,7 +12,6 @@ import {
 	EXECUTABLE_GLOBS,
 	MAX_QUICKPICK_RESULTS,
 	SIGNABLE_ARTIFACT_TIERS,
-	WORKSPACE_SEARCH_EXCLUDE_GLOB,
 	type WorkspaceFileSearch
 } from '../sign-utils';
 import { ARTIFACT_GLOBS } from '../artifact-types';
@@ -44,12 +43,7 @@ function findWorkspaceArtifacts(
 ): Promise<string[]> {
 	return findWorkspaceArtifactsCore(
 		workspacePath,
-		(includePattern, search) => glob(includePattern, {
-			cwd: workspacePath,
-			absolute: true,
-			nodir: true,
-			ignore: search.excludePattern
-		}),
+		includePattern => glob(includePattern, { cwd: workspacePath, absolute: true, nodir: true }),
 		patterns,
 		signal,
 		limit
@@ -187,7 +181,7 @@ describe('findWorkspaceArtifacts', () => {
 		assert.equal(receivedPattern, `{${ARTIFACT_GLOBS.join(',')}}`);
 	});
 
-	it('bounds discovery and excludes ignored directories at the finder', async () => {
+	it('bounds discovery without asking the finder to apply excludes', async () => {
 		const tempDir = createTempDir();
 		tempDirs.push(tempDir);
 		let received: WorkspaceFileSearch | undefined;
@@ -203,10 +197,62 @@ describe('findWorkspaceArtifacts', () => {
 			MAX_QUICKPICK_RESULTS
 		);
 
-		assert.equal(received?.excludePattern, WORKSPACE_SEARCH_EXCLUDE_GLOB);
+		// Excludes are applied after the search: passing one to the VS Code
+		// finder would also re-enable the user's `files.exclude` setting.
+		assert.deepEqual(Object.keys(received ?? {}).sort(), ['maxResults', 'signal']);
 		assert.ok(received?.maxResults !== undefined);
 		assert.ok(received.maxResults > MAX_QUICKPICK_RESULTS);
 		assert.ok(received.maxResults <= MAX_QUICKPICK_RESULTS * 4);
+	});
+
+	it('retries unbounded when ignored paths saturate the candidate pool', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const real = path.join(tempDir, 'real.msix');
+		createFile(real);
+		const ignored = Array.from({ length: 8 }, (_, index) =>
+			path.join(tempDir, 'node_modules', 'pkg', `dep${index}.msix`));
+		for (const filePath of ignored) {
+			createFile(filePath);
+		}
+		const requestedLimits: Array<number | undefined> = [];
+
+		const results = await findWorkspaceArtifactsCore(
+			tempDir,
+			async (_includePattern, search) => {
+				requestedLimits.push(search.maxResults);
+				// A capped search returns only ignored matches; unbounded finds the real one.
+				return search.maxResults === undefined ? [...ignored, real] : ignored.slice(0, search.maxResults);
+			},
+			ARTIFACT_GLOBS,
+			undefined,
+			2
+		);
+
+		assert.deepEqual(requestedLimits, [8, undefined]);
+		assert.deepEqual(results, [real]);
+	});
+
+	it('does not retry when the candidate pool was not saturated', async () => {
+		const tempDir = createTempDir();
+		tempDirs.push(tempDir);
+		const real = path.join(tempDir, 'real.msix');
+		createFile(real);
+		let calls = 0;
+
+		const results = await findWorkspaceArtifactsCore(
+			tempDir,
+			async () => {
+				calls++;
+				return [real];
+			},
+			ARTIFACT_GLOBS,
+			undefined,
+			2
+		);
+
+		assert.equal(calls, 1);
+		assert.deepEqual(results, [real]);
 	});
 
 	it('returns only the newest results up to the limit', async () => {
@@ -333,12 +379,7 @@ describe('findWorkspaceArtifactsByTier', () => {
 	): Promise<string[]> {
 		return findWorkspaceArtifactsByTier(
 			workspacePath,
-			(includePattern, search) => glob(includePattern, {
-				cwd: workspacePath,
-				absolute: true,
-				nodir: true,
-				ignore: search.excludePattern
-			}),
+			includePattern => glob(includePattern, { cwd: workspacePath, absolute: true, nodir: true }),
 			tiers,
 			signal,
 			limit

--- a/src/test/sign-utils.test.ts
+++ b/src/test/sign-utils.test.ts
@@ -231,11 +231,9 @@ describe('findWorkspaceArtifacts', () => {
 		assert.equal(calls, 0);
 	});
 
-	it('retries unbounded when ignored paths saturate the candidate pool', async () => {
+	it('never issues an unbounded search, even when ignored paths saturate the pool', async () => {
 		const tempDir = createTempDir();
 		tempDirs.push(tempDir);
-		const real = path.join(tempDir, 'real.msix');
-		createFile(real);
 		const ignored = Array.from({ length: 8 }, (_, index) =>
 			path.join(tempDir, 'node_modules', 'pkg', `dep${index}.msix`));
 		for (const filePath of ignored) {
@@ -243,51 +241,26 @@ describe('findWorkspaceArtifacts', () => {
 		}
 		const requestedLimits: Array<number | undefined> = [];
 
+		// Every match is ignored, so the pool is saturated and yields nothing.
+		// Discovery must accept that and stop rather than widen the search:
+		// "Browse…" is the escape hatch, not a full workspace walk.
 		const results = await findWorkspaceArtifactsCore(
 			tempDir,
 			async (_includePattern, search) => {
 				requestedLimits.push(search.maxResults);
-				// A capped search returns only ignored matches; unbounded finds the real one.
-				return search.maxResults === undefined ? [...ignored, real] : ignored.slice(0, search.maxResults);
+				return ignored.slice(0, search.maxResults);
 			},
 			ARTIFACT_GLOBS,
 			undefined,
 			2
 		);
 
-		assert.deepEqual(requestedLimits, [8, undefined]);
-		assert.deepEqual(results, [real]);
-	});
-
-	it('does not run the unbounded retry after cancellation', async () => {
-		const tempDir = createTempDir();
-		tempDirs.push(tempDir);
-		const ignored = Array.from({ length: 8 }, (_, index) =>
-			path.join(tempDir, 'node_modules', 'pkg', `dep${index}.msix`));
-		for (const filePath of ignored) {
-			createFile(filePath);
-		}
-		const controller = new AbortController();
-		const requestedLimits: Array<number | undefined> = [];
-
-		const results = await findWorkspaceArtifactsCore(
-			tempDir,
-			async (_includePattern, search) => {
-				requestedLimits.push(search.maxResults);
-				// Saturate the pool with ignored paths, then cancel before the retry.
-				controller.abort();
-				return ignored;
-			},
-			ARTIFACT_GLOBS,
-			controller.signal,
-			2
-		);
-
 		assert.deepEqual(requestedLimits, [8]);
+		assert.ok(requestedLimits.every((cap) => typeof cap === 'number'));
 		assert.deepEqual(results, []);
 	});
 
-	it('does not retry when the candidate pool was not saturated', async () => {
+	it('searches once per call', async () => {
 		const tempDir = createTempDir();
 		tempDirs.push(tempDir);
 		const real = path.join(tempDir, 'real.msix');
@@ -437,7 +410,7 @@ describe('createWorkspaceFileFinder', () => {
 		);
 
 		await finder('**/*.msix', { maxResults: 40 });
-		await finder('**/*.exe', { maxResults: undefined });
+		await finder('**/*.exe', { maxResults: 12 });
 
 		// A glob here would make VS Code also apply the user's `files.exclude`,
 		// which hides their own package output and empties the sign picker.


### PR DESCRIPTION
Fixes #150.

## Problem

`winapp.sign` discovered signable artifacts with an uncapped recursive glob and then `fs.stat`'d **every** match to sort newest-first. Cost scaled with the total number of matches in the workspace rather than the 10 rows the QuickPick actually shows — so a repo with a large `node_modules` or years of build output paid for a full walk to render ten entries.

The issue title says "package discovery," but the behavior applied to all three glob sets: `ARTIFACT_GLOBS`, `EXECUTABLE_GLOBS`, and `CERTIFICATE_GLOBS`.

## Approach

Discovery is now **capped and tiered**:

| Tier | Extensions |
|------|-----------|
| 1 | `.msix`, `.msixbundle` |
| 2 | everything else in `ARTIFACT_EXTENSIONS` (currently `.appx`, `.appxbundle`) |
| 3 | `.exe`, `.dll` |

Each tier is sorted newest-first **independently** and lower tiers run only if slots remain, so a package always outranks a loose executable regardless of mtime. Tier 2 is derived from `ARTIFACT_EXTENSIONS` rather than hardcoded, so a future artifact type gets a tier without edits here.

`MAX_QUICKPICK_RESULTS = 10`, and `"Browse…"` is always present as the escape hatch for anything not surfaced. Per review, the picker deliberately shows **no truncation message** — just the entries and Browse.

### Why a candidate pool exists

`findFiles` with `maxResults: 10` returns the first 10 it *encounters*, not the 10 newest — it stops walking early, so sorting them sorts an arbitrary sample. #150 calls this out. We collect `limit * 4`, sort, then slice. Concretely: with 60 `.msix` files walked in roughly alphabetical order, `maxResults: 10` returns the ten *oldest* and today's build is absent; a 40-candidate pool finds it.

The pool is a fidelity/cost dial, not a result count. It is bounded in all cases.

## Two non-obvious findings worth reviewer attention

**1. `findFiles` must be called with `exclude: null`.**

Passing *any* explicit exclude glob makes VS Code **additionally** apply the user's `files.exclude` setting. Only `null` opts out — per `@types/vscode`: *"When `undefined`, default file-excludes (e.g. the `files.exclude`-setting…) will apply. When `null`, no excludes will apply."*

This matters because users commonly hide package output (`"files.exclude": {"**/AppPackages": true}`) while still wanting to sign what's inside. Getting it wrong produces a **completely empty** sign picker. I verified this empirically — swapping in `{**/node_modules/**,**/.git/**}` made the picker find zero artifacts and never open.

`node_modules`/`.git` are therefore filtered *after* the search. The API that would decouple these two concerns (`findFiles2`'s `useDefaultExcludes`) is proposed-only and absent from `@types/vscode` 1.125.

This is defended three ways: `FindFilesApi` types `exclude` as `null` so a glob is a compile error, a unit test asserts no exclude is ever passed, and an e2e test runs against a workspace with `files.exclude` set. **This exact change has now been proposed and rejected twice in review** — please read the guard tests before "simplifying" it.

**2. Discovery never runs unbounded.**

An earlier revision retried without a cap when ignored paths saturated the pool. That was removed: it reintroduced the exact cost profile this PR removes, and fired precisely in the workspace where it hurts most (a large `node_modules`). `maxResults` is now a required `number` through `WorkspaceFileSearch` and `FindFilesApi`, so an unbounded search won't compile.

## Sign picker rows now match every other picker

The sign and certificate pickers were the **only** pickers rendering at double height. They passed the absolute path in `detail`, which adds a second line per row.

Measured in-product (both lists get the same 321px):

| Picker | Item shape | Row height | Entries that fit |
|---|---|---|---|
| Command Palette / `init` project picker | `label` + `description` | 22px | ~14 |
| `sign` picker (before) | `label` + `description` + `detail` | **44px** | **7 of 11** |

So `Browse…` — the entire fallback for a capped list — sat below the fold.

`detail` was redundant rather than informative: it held the workspace root joined to `description` and `label`, and `getWorkspacePath()` always returns `workspaceFolders[0]`, so it repeated the *same prefix* on all 10 rows. Removing it loses nothing that `label` + `description` don't already convey, and makes sign structurally identical to `ProjectQuickPickItem` in `project-resolver.ts`.

Row height is unchanged from the product standard — sign just stops being the outlier. All 11 entries now fit without scrolling. The Browse hint moved from `detail` to `description` so that row matches too.

An e2e assertion pins row height to 22px and requires all 11 entries fully visible, so a future `detail` field can't silently reintroduce the overflow.

Also worth noting: `init` caps at 10 as well (`MAX_SCANNED_PROJECTS`), so the two commands are now consistent on both count and row height.

Retained from this work is a dedicated `filePath` payload field, which is how the caller distinguishes a discovered file from Browse — it replaces a `picked.detail === FILE_PICKER_DETAIL` string sentinel.

## Also fixed

**A latent bug in the old code.** It concatenated packages + executables and *then* sliced to 10, so executables were invisible whenever ≥10 packages existed.

**Two real e2e test bugs** (not flake — they failed 5/8 consistently):
- Tests waited on "any list row is visible," which the **Command Palette's own rows** satisfy: pressing Enter doesn't close the palette synchronously. Every one-shot read after that point raced the transition and observed palette state. Now `waitForQuickPick()` polls the placeholder, which is unique per picker.
- Dismissal tests asserted row count drops to 0. VS Code hides the widget but leaves rendered rows in the DOM, so that could never pass. Now asserts widget visibility.

## Testing

- 44/44 unit tests (`sign-utils` + `sign-flow`)
- 8/8 `sign-quickpick.spec.ts` e2e, stable across repeated sequential runs
- Re-ran the e2e suite against the **packaged VSIX** (`E2E_USE_INSTALLED_EXTENSION=1`) — 8/8, confirming the production esbuild output behaves identically
- Full `scripts\build-vsce.ps1 -Package` pipeline green; `tsc --noEmit` and `lint` clean

New coverage: tier ordering independent of mtime, the 10-cap, row height and Browse visibility, `files.exclude` immunity, zero/negative limits, cancellation, and that no unbounded search is ever issued.

## Review notes

- ~65% of the diff is tests and docs.
- No new commands, settings, activation events, or dependencies — behavior change to an existing command, so no `package.json` or packaging updates were required.